### PR TITLE
Fix text diff representation of changes that span over multiple lines

### DIFF
--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -28,12 +28,7 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
   | None -> Ok 0
   | Some diff ->
       let text_diff = Api_watch.Text_diff.from_diff diff in
-      let print_module_diff module_path diff =
-        Printf.printf "diff module %s:\n" module_path;
-        Diffutils.Diff.pp Diffutils.Diff.git_printer Format.std_formatter diff;
-        Printf.printf "\n"
-      in
-      Api_watch.String_map.iter print_module_diff text_diff;
+      Api_watch.Text_diff.pp Format.std_formatter text_diff;
       Ok 1
 
 let named f = Cmdliner.Term.(app (const f))

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -88,3 +88,11 @@ let from_diff (diff : Diff.module_) : Diffutils.Diff.t String_map.t =
           acc changes
   in
   process_module_diff diff.mname diff String_map.empty
+
+let pp fmt t =
+  let print_module_diff module_path diff =
+    Format.fprintf fmt "diff module %s:\n" module_path;
+    Diffutils.Diff.pp Diffutils.Diff.git_printer Format.std_formatter diff;
+    Format.fprintf fmt "\n"
+  in
+  String_map.iter print_module_diff t

--- a/lib/text_diff.mli
+++ b/lib/text_diff.mli
@@ -21,3 +21,6 @@ type t = Diffutils.Diff.t String_map.t
     ones. *)
 
 val from_diff : Diff.module_ -> Diffutils.Diff.t String_map.t
+
+val pp : Format.formatter -> t -> unit
+(** Pretty-print the text diff in a human readable, git diff like format. *)

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -47,8 +47,8 @@ Run api-watcher on the two cmi files, there should be a difference
 
   $ api-diff ref.cmi add_type.cmi
   diff module Add_type:
-  
   +<unsupported change>
+  
   [1]
 
 ### A file with a removed type:
@@ -66,8 +66,8 @@ Run api-watcher on the two cmi files, there should be a difference
 
   $ api-diff ref.cmi remove_type.cmi
   diff module Remove_type:
-  
   +<unsupported change>
+  
   [1]
 
 ### A file with a modified type:
@@ -86,8 +86,8 @@ Run api-watcher on the two cmi files, there should be a difference
 
   $ api-diff ref.cmi modify_type.cmi
   diff module Modify_type:
-  
   +<unsupported change>
+  
   [1]
 
 ## Different .cmi files for value tests:
@@ -108,8 +108,8 @@ Compile the new .mli file to a .cmi file
 Run api-diff and check the output
   $ api-diff ref.cmi add_value.cmi
   diff module Add_value:
-  
   +val g : t -> t
+  
   [1]
 
 ### Removing a value:
@@ -126,8 +126,8 @@ Compile the new .mli file to a .cmi file
 Run api-diff and check the output
   $ api-diff ref.cmi remove_value.cmi
   diff module Remove_value:
-  
   -val f : t -> string
+  
   [1]
 
 ### Modifying a value:
@@ -145,9 +145,9 @@ Compile the new .mli file to a .cmi file
 Run api-diff and check the output
   $ api-diff ref.cmi modify_value.cmi
   diff module Modify_value:
-  
   -val f : t -> string
   +val f : t -> t
+  
   [1]
 
 Here we generate a `.mli` file with a module:
@@ -181,8 +181,8 @@ Compile the new .mli file to a .cmi file
 Run api-diff and check the output
   $ api-diff mod_ref.cmi add_module.cmi
   diff module Add_module:
-  
   +module N: sig val y : float end
+  
   [1]
 
 ### Removing a module:
@@ -198,8 +198,8 @@ Compile the new .mli file to a .cmi file
 Run api-diff and check the output
   $ api-diff mod_ref.cmi remove_module.cmi
   diff module Remove_module:
-  
   -module M: sig val x : int end
+  
   [1]
 
 ### Modifying a module:
@@ -216,9 +216,9 @@ Compile the new .mli file to a .cmi file
 Run api-diff and check the output
   $ api-diff mod_ref.cmi modify_module.cmi
   diff module Modify_module.M:
-  
   -val x : int
   +val x : float
+  
   [1]
 
 Generate a new .mli file with values and submodules

--- a/tests/api-watch/test_text_diff.ml
+++ b/tests/api-watch/test_text_diff.ml
@@ -29,11 +29,11 @@ let%expect_test "multi-line items are represented as multi-line diffs" =
     {|
     diff module Main:
     +val f :
-      some_long_labeled_argument:int ->
-      some_other_long_labeled_arg:int * int -> string * string -> unit -> string
+    +  some_long_labeled_argument:int ->
+    +  some_other_long_labeled_arg:int * int -> string * string -> unit -> string
     +module M: sig
-      val some_val : int -> int -> int -> string
-      val some_other_val : string -> string -> string -> int
-      val yet_some_other_val : string -> bool -> string
-    end
+    +  val some_val : int -> int -> int -> string
+    +  val some_other_val : string -> string -> string -> int
+    +  val yet_some_other_val : string -> bool -> string
+    +end
     |}]

--- a/tests/api-watch/test_text_diff.ml
+++ b/tests/api-watch/test_text_diff.ml
@@ -1,0 +1,39 @@
+open Api_watch
+open Test_helpers
+
+let%expect_test "multi-line items are represented as multi-line diffs" =
+  let reference = compile_interface {|
+      |} in
+  let current =
+    compile_interface
+      {|
+      val f :
+        some_long_labeled_argument: int ->
+        some_other_long_labeled_arg: int * int ->
+        string * string ->
+        unit ->
+        string
+
+      module M : sig
+        val some_val : int -> int -> int -> string
+        val some_other_val : string -> string -> string -> int
+        val yet_some_other_val : string -> bool -> string
+      end
+      |}
+  in
+  let diff_opt = Diff.interface ~module_name:"Main" ~reference ~current in
+  let diff = Option.get diff_opt in
+  let text_diff = Text_diff.from_diff diff in
+  Format.printf "%a" Text_diff.pp text_diff;
+  [%expect
+    {|
+    diff module Main:
+    +val f :
+      some_long_labeled_argument:int ->
+      some_other_long_labeled_arg:int * int -> string * string -> unit -> string
+    +module M: sig
+      val some_val : int -> int -> int -> string
+      val some_other_val : string -> string -> string -> int
+      val yet_some_other_val : string -> bool -> string
+    end
+    |}]


### PR DESCRIPTION
Diffs were previously not properly converted to text diffs when an individual value or module change would span over several lines.

It was turned into a single line of diff but was pretty printed over multiple lines, ending up in a misrepresented diff.

This adds a regression tests and a subsequent fix.

To simplify all this I extracted a `Text_diff.pp` function which I used to write an expect tests.