### PR TITLE
Explicitly pass the main module name through the command line

### DIFF
--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -1,3 +1,5 @@
+let tool_name = "api-diff"
+
 let run (`Main_module main_module) (`Ref_cmi reference) (`Current_cmi current) =
   let open CCResult.Infix in
   let* reference_sig, current_sig, module_name =
@@ -15,8 +17,8 @@ let run (`Main_module main_module) (`Ref_cmi reference) (`Current_cmi current) =
           | None -> ()
           | Some _ ->
               Printf.eprintf
-                "%s: --main-module ignored when diffing single .cmi files"
-                Sys.executable_name
+                "%s: --main-module ignored when diffing single .cmi files\n"
+                tool_name
         in
         let+ reference_cmi, _ = Api_watch.Library.load_cmi reference
         and+ current_cmi, module_name = Api_watch.Library.load_cmi current in
@@ -73,7 +75,7 @@ let current_cmi =
 
 let info =
   let open Cmdliner in
-  Cmd.info "api-watcher" ~version:"%%VERSION%%" ~exits:Cmd.Exit.defaults
+  Cmd.info tool_name ~version:"%%VERSION%%" ~exits:Cmd.Exit.defaults
     ~doc:"List API changes between two versions of a library"
 
 let term = Cmdliner.Term.(const run $ main_module $ ref_cmi $ current_cmi)

--- a/tests/api-diff/errors.t
+++ b/tests/api-diff/errors.t
@@ -4,12 +4,21 @@ diff a .cmi file with another .cmi file or a directory with a directory
   $ mkdir test
   $ touch test.cmi
   $ api-diff test test.cmi
-  api-watcher: Arguments must either both be directories or both single .cmi files.
+  api-diff: Arguments must either both be directories or both single .cmi files.
   [123]
 
 When diffing all libraries, the --main-module argument is mandatory
 
   $ mkdir test2
   $ api-diff test test2
-  api-watcher: --main-module must be provided when diffing entire libraries.
+  api-diff: --main-module must be provided when diffing entire libraries.
+  [123]
+
+When passing --main-module while diffing single .cmi files, the user will be warn
+that it is ignored
+
+  $ touch test2.cmi
+  $ api-diff --main-module main test.cmi test2.cmi
+  api-diff: --main-module ignored when diffing single .cmi files
+  api-diff: Cmi_format.Error(_)
   [123]

--- a/tests/api-diff/errors.t
+++ b/tests/api-diff/errors.t
@@ -1,0 +1,15 @@
+api-diff only accepts arguments of the same nature, that is it either
+diff a .cmi file with another .cmi file or a directory with a directory
+
+  $ mkdir test
+  $ touch test.cmi
+  $ api-diff test test.cmi
+  api-watcher: Arguments must either both be directories or both single .cmi files.
+  [123]
+
+When diffing all libraries, the --main-module argument is mandatory
+
+  $ mkdir test2
+  $ api-diff test test2
+  api-watcher: --main-module must be provided when diffing entire libraries.
+  [123]

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -364,17 +364,17 @@ Build the second version
   $ cd project_v2 && dune build && cd ..
 
 Run the api-diff tool on the two project versions
-  $ api-diff project_v1/_build/default/lib/.mylib.objs/byte project_v2/_build/default/lib/.mylib.objs/byte
-  diff module project_v2.Mylib__Math:
+  $ api-diff --main-module myproject  project_v1/_build/default/lib/.mylib.objs/byte project_v2/_build/default/lib/.mylib.objs/byte
+  diff module Myproject.Mylib__Math:
   -val add : int -> int -> int
   +val add : int -> int -> int -> int
   +val multiply : int -> int -> int
   +module New_module: sig val hello : unit -> string end
   
-  diff module project_v2.Mylib__Math.Advanced:
+  diff module Myproject.Mylib__Math.Advanced:
   +val cube : int -> int
   
-  diff module project_v2.Mylib__Utils:
+  diff module Myproject.Mylib__Utils:
   +val triple : int -> int
   
   [1]


### PR DESCRIPTION
This used to rely on some inference based on parent directories which was unpractical and unreliable.