### PR TITLE
Make api-diff output colored

### DIFF
--- a/api-watch.opam
+++ b/api-watch.opam
@@ -13,6 +13,7 @@ depends: [
   "ppx_deriving"
   "logs"
   "containers"
+  "fmt"
   "cmdliner" {>= "1.1.0"}
   "diffutils"
   "odoc" {with-doc}

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -37,7 +37,7 @@ let run (`Main_module main_module) (`Ref_cmi reference) (`Current_cmi current) =
   | None -> Ok 0
   | Some diff ->
       let text_diff = Api_watch.Text_diff.from_diff diff in
-      Api_watch.Text_diff.pp Format.std_formatter text_diff;
+      Api_watch.Text_diff.With_colors.pp Format.std_formatter text_diff;
       Ok 1
 
 let named f = Cmdliner.Term.(app (const f))
@@ -81,5 +81,6 @@ let info =
 let term = Cmdliner.Term.(const run $ main_module $ ref_cmi $ current_cmi)
 
 let () =
+  Fmt_tty.setup_std_outputs ();
   let exit_code = Cmdliner.Cmd.eval_result' (Cmdliner.Cmd.v info term) in
   exit exit_code

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (name api_diff)
  (public_name api-diff)
- (libraries api-watch cmdliner compiler-libs.common))
+ (libraries api-watch cmdliner compiler-libs.common fmt.tty))

--- a/dune-project
+++ b/dune-project
@@ -20,5 +20,6 @@
   ppx_deriving
   logs
   containers
+  fmt
   (cmdliner (>= 1.1.0))
   diffutils))

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
  (public_name api-watch)
  (preprocess
   (pps ppx_deriving.std))
- (libraries compiler-libs.common diffutils unix containers))
+ (libraries compiler-libs.common diffutils unix containers fmt))

--- a/lib/text_diff.mli
+++ b/lib/text_diff.mli
@@ -24,3 +24,9 @@ val from_diff : Diff.module_ -> Diffutils.Diff.t String_map.t
 
 val pp : Format.formatter -> t -> unit
 (** Pretty-print the text diff in a human readable, git diff like format. *)
+
+module With_colors : sig
+  val pp : Format.formatter -> t -> unit
+  (** Same as regular [pp] but prints added lines in green and removed lines
+    in red. *)
+end


### PR DESCRIPTION
Fixes #72 

This makes `api-diff` output colored in a git diff like manner, green for new lines, red for removed lines, white for kept lines.