### PR TITLE
Remove diffutils pin depends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- Remove dependency on unreleased `diffutils` package
+  (#88, #95, @azzsal)
+
 ### Removed
 
 ### Security

--- a/api-watch.opam
+++ b/api-watch.opam
@@ -15,7 +15,6 @@ depends: [
   "containers"
   "fmt"
   "cmdliner" {>= "1.1.0"}
-  "diffutils"
   "ocamlformat" {with-dev-setup & = "0.26.2"}
   "odoc" {with-doc}
 ]
@@ -34,6 +33,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/NathanReb/ocaml-api-watch.git"
-pin-depends: [
-  ["diffutils.dev" "git+https://github.com/panglesd/ocaml-diffutils#0fc293bc0cd2c34742552f7a0c777bfba385bd90"]
-]

--- a/api-watch.opam.template
+++ b/api-watch.opam.template
@@ -1,3 +1,0 @@
-pin-depends: [
-  ["diffutils.dev" "git+https://github.com/panglesd/ocaml-diffutils#0fc293bc0cd2c34742552f7a0c777bfba385bd90"]
-]

--- a/dune-project
+++ b/dune-project
@@ -22,5 +22,4 @@
   containers
   fmt
   (cmdliner (>= 1.1.0))
-  diffutils
   (ocamlformat (and :with-dev-setup (= 0.26.2)))))


### PR DESCRIPTION
This complements #88 by removing the actual opam dependency so we can release the initial prototype.