### PR TITLE
Detect addition and removal of class type declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - Add detection of type declarations changes (#92, @azzsal)
 - Add detection of module_type declarations changes (#93, @NchamJosephMuam)
 - Add detection of classes addition and removal (#90, @marcndo)
-- Add detection of addition and removal of class type declarations (#92, @azzsal)
+- Add detection of addition and removal of class type declarations (#103, @azzsal)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@
 
 ### Added
 
-- Add detection of modified type declarations (#92, @azzsal)
+- Add detection of type declarations changes (#92, @azzsal)
 - Add detection of module_type declarations changes (#93, @NchamJosephMuam)
 - Add detection of classes addition and removal (#90, @marcndo)
+- Add detection of addition and removal of class type declarations (#92, @azzsal)
 
 ### Changed
 

--- a/lib/diff.ml
+++ b/lib/diff.ml
@@ -19,14 +19,14 @@ type type_ = {
 
 type class_modification = Unsupported
 
-and class_ = {
+type class_ = {
   cname : string;
   cdiff : (class_declaration, class_modification) t;
 }
 
 type class_type_modification = Unsupported
 
-and cltype = {
+type cltype = {
   ctname : string;
   ctdiff : (class_type_declaration, class_type_modification) t;
 }

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -7,12 +7,19 @@ type value = {
     (Types.value_description, Types.value_description atomic_modification) t;
 }
 
-type class_ = {
+type class_modification = Unsupported
+
+and class_ = {
   cname : string;
   cdiff : (Types.class_declaration, class_modification) t;
 }
 
-and class_modification = Unsupported
+type class_type_modification = Unsupported
+
+and cltype = {
+  ctname : string;
+  ctdiff : (Types.class_type_declaration, class_type_modification) t;
+}
 
 type type_ = {
   tname : string;
@@ -37,6 +44,7 @@ and sig_item =
   | Type of type_
   | Modtype of modtype
   | Class of class_
+  | Classtype of cltype
 
 val interface :
   module_name:string ->

--- a/lib/sig_item_map.mli
+++ b/lib/sig_item_map.mli
@@ -8,6 +8,7 @@ type _ item_type =
   | Modtype : modtype_declaration item_type
   | Type : (type_declaration * Ident.t) item_type
   | Class : class_declaration item_type
+  | Classtype : class_type_declaration item_type
 
 val empty : t
 val add : name:string -> 'a item_type -> 'a -> t -> t

--- a/tests/api-diff/class_detection.t
+++ b/tests/api-diff/class_detection.t
@@ -34,6 +34,7 @@ Run api-diff and check the output
   diff module Add_class:
   +type add_class = < calculate : float -> float >
   +class add_class : object method calculate : float -> float end
+  +class type add_class = object method calculate : float -> float end
   
   [1]
 
@@ -51,5 +52,6 @@ Run api-diff and check the output
   diff module Remove_class:
   -type ref_class = < get : int; set : int -> unit >
   -class ref_class : object method get : int method set : int -> unit end
+  -class type ref_class = object method get : int method set : int -> unit end
   
   [1]

--- a/tests/api-diff/cltype_tests.t
+++ b/tests/api-diff/cltype_tests.t
@@ -1,0 +1,58 @@
+Here we generate a basic `.mli` file with a class type declaration (class interface):
+
+  $ cat > ref_cltype.mli << EOF
+  > class type ref_cltype = object
+  >   method m1 : string
+  >   method m2 : string -> unit
+  > end 
+  > EOF
+
+We generate .cmi file
+  $ ocamlc ref_cltype.mli
+
+Now, we run api-diff on the same cmi file as both arguments, there should be no difference
+  $ api-diff ref_cltype.cmi ref_cltype.cmi
+
+### Adding a new class type:
+
+Generate a new .mli file with an additional class type
+  $ cat > add_cltype.mli << EOF
+  > class type ref_cltype = object
+  >    method m1 : string 
+  >    method m2 : string -> unit
+  > end
+  > class type new_cltype = object
+  >    method mk : int -> unit
+  >    method mn : int -> int
+  > end
+  > EOF
+
+Compile the new .mli file to a .cmi file
+  $ ocamlc add_cltype.mli
+
+Run api-diff and check the output
+  $ api-diff ref_cltype.cmi add_cltype.cmi
+  diff module Add_cltype:
+  +type new_cltype = < mk : int -> unit; mn : int -> int >
+  +class type new_cltype =
+  +  object method mk : int -> unit method mn : int -> int end
+  
+  [1]
+
+### Removing a class type:
+
+Generate a new .mli file with the class type now removed
+  $ cat > remove_cltype.mli << EOF
+  > EOF
+
+Compile the new .mli file to a .cmi file
+  $ ocamlc remove_cltype.mli
+
+Run api-diff and check the output
+  $ api-diff ref_cltype.cmi remove_cltype.cmi
+  diff module Remove_cltype:
+  -type ref_cltype = < m1 : string; m2 : string -> unit >
+  -class type ref_cltype =
+  -  object method m1 : string method m2 : string -> unit end
+  
+  [1]

--- a/tests/api-watch/test_diff_class.ml
+++ b/tests/api-watch/test_diff_class.ml
@@ -35,9 +35,10 @@ let%expect_test "Class Addition" =
     Format.printf "%a" pp_diff_option result;
     [%expect
       {|
-    Some (Module Main: {Modified (Supported [ Type (cls3, Added);
-    Class (cls3, Added)])})
-    |}]
+      Some (Module Main: {Modified (Supported [ Type (cls3, Added);
+      Class (cls3, Added);
+      Class_type (cls3, Added)])})
+      |}]
   with e ->
     Format.printf "Error: %s" (Printexc.to_string e);
     [%expect.unreachable]
@@ -69,7 +70,8 @@ let%expect_test "Class Removal" =
     [%expect
       {|
     Some (Module Main: {Modified (Supported [ Type (cls2, Removed);
-    Class (cls2, Removed)])})
+    Class (cls2, Removed);
+    Class_type (cls2, Removed)])})
     |}]
   with e ->
     Format.printf "Error: %s" (Printexc.to_string e);

--- a/tests/api-watch/test_diff_cltype.ml
+++ b/tests/api-watch/test_diff_cltype.ml
@@ -1,0 +1,42 @@
+open Api_watch
+open Test_helpers
+
+let%expect_test "Class type addition" =
+  let reference = compile_interface {||} in
+  let current =
+    compile_interface
+      {| 
+        class type cltype = 
+          object 
+            method m1 : float 
+            method m2 : int -> int 
+        end 
+      |}
+  in
+  let result = Diff.interface ~module_name:"Main" ~reference ~current in
+  Format.printf "%a" pp_diff_option result;
+  [%expect
+    {|
+      Some (Module Main: {Modified (Supported [ Type (cltype, Added);
+      Class_type (cltype, Added)])})
+    |}]
+
+let%expect_test "Class type removal" =
+  let reference =
+    compile_interface
+      {| 
+        class type cltype = 
+          object 
+            method m1 : float 
+            method m2 : int -> int 
+        end 
+      |}
+  in
+  let current = compile_interface {||} in
+  let result = Diff.interface ~module_name:"Main" ~reference ~current in
+  Format.printf "%a" pp_diff_option result;
+  [%expect
+    {|
+        Some (Module Main: {Modified (Supported [ Type (cltype, Removed);
+        Class_type (cltype, Removed)])})
+      |}]

--- a/tests/test_helpers/test_helpers.ml
+++ b/tests/test_helpers/test_helpers.ml
@@ -15,6 +15,7 @@ and pp_item_diff fmt = function
   | Type type_diff -> pp_type_diff fmt type_diff
   | Modtype module_type_diff -> pp_module_type_diff fmt module_type_diff
   | Class class_diff -> pp_class_diff fmt class_diff
+  | Classtype class_type_diff -> pp_class_type_diff fmt class_type_diff
 
 and pp_value_diff fmt { vname; vdiff } =
   match vdiff with
@@ -49,6 +50,12 @@ and pp_class_diff fmt { cname; cdiff } =
   | Added _ -> Format.fprintf fmt "Class (%s, Added)" cname
   | Removed _ -> Format.fprintf fmt "Class (%s, Removed)" cname
   | Modified _ -> Format.fprintf fmt "Class (%s, Modified)" cname
+
+and pp_class_type_diff fmt { ctname; ctdiff } =
+  match ctdiff with
+  | Added _ -> Format.fprintf fmt "Class_type (%s, Added)" ctname
+  | Removed _ -> Format.fprintf fmt "Class_type (%s, Removed)" ctname
+  | Modified _ -> Format.fprintf fmt "Class_type (%s, Modified)" ctname
 
 let pp_diff_option fmt = function
   | None -> Format.fprintf fmt "None"


### PR DESCRIPTION
This aims to fix #83. Sorry about the delay.

There is a bit of code duplication with class declarations code. I will fix that, if you have an approach in mind, please let me know.

As with class declarations, a type is added when a class type declaration is added. Also a class type is added when a class declaration is added. This could be a bit confusing for a user of our tool/library. I think that should be fixed, but maybe by a different issue/PR.