### PR TITLE
Add Support for unwrapped libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Add detection of module_type declarations changes (#93, @NchamJosephMuam)
 - Add detection of classes addition and removal (#90, @marcndo)
 - Add detection of addition and removal of class type declarations (#103, @azzsal)
+- Add initial support for unwrapped libraries (#107, @Siddhi-agg, @azzsal)
 
 ### Changed
 

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -47,8 +47,10 @@ let run (`Main_module main_module) (`Unwrapped_library unwrapped)
     match curr_mode with
     | Wrapped main_module ->
         let main_module = String.capitalize_ascii main_module in
-        let+ reference_sig = Api_watch.Library.load ~main_module reference
-        and+ current_sig = Api_watch.Library.load ~main_module current in
+        let+ reference_map = Api_watch.Library.load ~main_module reference
+        and+ current_map = Api_watch.Library.load ~main_module current in
+        let reference_sig = Api_watch.String_map.find main_module reference_map in
+        let current_sig = Api_watch.String_map.find main_module current_map in
         let module_name = String.capitalize_ascii main_module in
         (reference_sig, current_sig, module_name)
     | Unwrapped -> failwith "TODO: Call Api_watch.Library.load_unwrapped"

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -49,7 +49,9 @@ let run (`Main_module main_module) (`Unwrapped_library unwrapped)
         let main_module = String.capitalize_ascii main_module in
         let+ reference_map = Api_watch.Library.load ~main_module reference
         and+ current_map = Api_watch.Library.load ~main_module current in
-        let reference_sig = Api_watch.String_map.find main_module reference_map in
+        let reference_sig =
+          Api_watch.String_map.find main_module reference_map
+        in
         let current_sig = Api_watch.String_map.find main_module current_map in
         let module_name = String.capitalize_ascii main_module in
         (reference_sig, current_sig, module_name)

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -10,29 +10,29 @@ let both_directories reference current =
       Error
         "Arguments must either both be directories or both single .cmi files."
 
+let print_warning main_module unwrapped =
+  match (main_module, unwrapped) with
+  | None, false -> ()
+  | Some _, false ->
+      Printf.eprintf
+        "%s: --main-module is ignored when diffing single .cmi files\n"
+        tool_name
+  | None, true ->
+      Printf.eprintf
+        "%s: --unwrapped is ignored when diffing single .cmi files\n" tool_name
+  | Some _, true ->
+      Printf.eprintf
+        "%s: --main-module and --unwrapped are ignored when diffing single \
+         .cmi files\n"
+        tool_name
+
 let mode ~reference ~current ~main_module ~unwrapped =
   match (both_directories reference current, main_module, unwrapped) with
   | Ok true, Some main_module, false -> Ok (Wrapped main_module)
   | Ok true, None, true -> Ok Unwrapped
-  | Ok false, main_module, unwrapped -> (
-      match (main_module, unwrapped) with
-      | None, false -> Ok Cmi
-      | Some _, false ->
-          Printf.eprintf
-            "%s: --main-module is ignored when diffing single .cmi files\n"
-            tool_name;
-          Ok Cmi
-      | None, true ->
-          Printf.eprintf
-            "%s: --unwrapped is ignored when diffing single .cmi files\n"
-            tool_name;
-          Ok Cmi
-      | Some _, true ->
-          Printf.eprintf
-            "%s: --main-module and --unwrapped are ignored when diffing single \
-             .cmi files\n"
-            tool_name;
-          Ok Cmi)
+  | Ok false, main_module, unwrapped ->
+      print_warning main_module unwrapped;
+      Ok Cmi
   | (Error _ as e), _, _ -> e
   | Ok true, _, _ ->
       Error

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -42,14 +42,14 @@ let mode ~reference ~current ~main_module ~unwrapped =
 let run (`Main_module main_module) (`Unwrapped_library unwrapped)
     (`Ref_cmi reference) (`Current_cmi current) =
   let open CCResult.Infix in
-  let* reference_sig, current_sig =
+  let* reference_map, current_map =
     let* curr_mode = mode ~reference ~current ~main_module ~unwrapped in
     match curr_mode with
     | Wrapped main_module ->
         let main_module = String.capitalize_ascii main_module in
-        let+ reference_sig = Api_watch.Library.load ~main_module reference
-        and+ current_sig = Api_watch.Library.load ~main_module current in
-        (reference_sig, current_sig)
+        let+ reference_map = Api_watch.Library.load ~main_module reference
+        and+ current_map = Api_watch.Library.load ~main_module current in
+        (reference_map, current_map)
     | Unwrapped ->
         let+ reference_map = Api_watch.Library.load_unwrapped reference
         and+ current_map = Api_watch.Library.load_unwrapped current in
@@ -57,16 +57,16 @@ let run (`Main_module main_module) (`Unwrapped_library unwrapped)
     | Cmi ->
         let+ reference_cmi, _ = Api_watch.Library.load_cmi reference
         and+ current_cmi, module_name = Api_watch.Library.load_cmi current in
-        let reference_sig =
+        let reference_map =
           Api_watch.String_map.singleton module_name reference_cmi
         in
-        let current_sig =
+        let current_map =
           Api_watch.String_map.singleton module_name current_cmi
         in
-        (reference_sig, current_sig)
+        (reference_map, current_map)
   in
   let diff_map =
-    Api_watch.Diff.library ~reference:reference_sig ~current:current_sig
+    Api_watch.Diff.library ~reference:reference_map ~current:current_map
     |> Api_watch.String_map.bindings
     |> List.filter_map (fun (_, v) -> v)
   in

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -70,15 +70,13 @@ let run (`Main_module main_module) (`Unwrapped_library unwrapped)
     |> Api_watch.String_map.bindings
     |> List.filter_map (fun (_, v) -> v)
   in
-  let has_diff =
-    List.exists
-      (fun diff ->
-        let text_diff = Api_watch.Text_diff.from_diff diff in
-        Api_watch.Text_diff.With_colors.pp Format.std_formatter text_diff;
-        true)
-      diff_map
-  in
-  if has_diff then Ok 1 else Ok 0
+  let has_changes = not (List.is_empty diff_map) in
+  List.iter
+    (fun diff ->
+      let text_diff = Api_watch.Text_diff.from_diff diff in
+      Api_watch.Text_diff.With_colors.pp Format.std_formatter text_diff)
+    diff_map;
+  if has_changes then Ok 1 else Ok 0
 
 let named f = Cmdliner.Term.(app (const f))
 

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -27,14 +27,15 @@ let print_warning main_module unwrapped =
         tool_name
 
 let mode ~reference ~current ~main_module ~unwrapped =
-  match (both_directories reference current, main_module, unwrapped) with
-  | Ok true, Some main_module, false -> Ok (Wrapped main_module)
-  | Ok true, None, true -> Ok Unwrapped
-  | Ok false, main_module, unwrapped ->
+  let open CCResult.Infix in
+  let* both_dirs = both_directories reference current in
+  match (both_dirs, main_module, unwrapped) with
+  | true, Some main_module, false -> Ok (Wrapped main_module)
+  | true, None, true -> Ok Unwrapped
+  | false, main_module, unwrapped ->
       print_warning main_module unwrapped;
       Ok Cmi
-  | (Error _ as e), _, _ -> e
-  | Ok true, _, _ ->
+  | true, _, _ ->
       Error
         "Either --main-module or --unwrapped must be provided when diffing \
          entire libraries."

--- a/dev-tools/print_api.ml
+++ b/dev-tools/print_api.ml
@@ -22,7 +22,7 @@ let run (`Main_module main_module) (`Input fn) =
       Ok ()
   | true, Some main_module ->
       let+ sig_map = Api_watch.Library.load ~main_module fn in
-      let sig_ = Api_watch.String_map.find main_module sig_map in 
+      let sig_ = Api_watch.String_map.find main_module sig_map in
       Printtyp.signature Format.std_formatter sig_;
       Format.printf "\n"
 

--- a/dev-tools/print_api.ml
+++ b/dev-tools/print_api.ml
@@ -21,7 +21,8 @@ let run (`Main_module main_module) (`Input fn) =
       List.iter print_cmi cmi_files;
       Ok ()
   | true, Some main_module ->
-      let+ sig_ = Api_watch.Library.load ~main_module fn in
+      let+ sig_map = Api_watch.Library.load ~main_module fn in
+      let sig_ = Api_watch.String_map.find main_module sig_map in 
       Printtyp.signature Format.std_formatter sig_;
       Format.printf "\n"
 

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -53,6 +53,4 @@ val interface :
   module_ option
 
 val library :
-  reference:Types.signature String_map.t ->
-  current:Types.signature String_map.t ->
-  module_ option String_map.t
+  reference:Library.t -> current:Library.t -> module_ option String_map.t

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -51,3 +51,8 @@ val interface :
   reference:Types.signature ->
   current:Types.signature ->
   module_ option
+
+val library :
+  reference:Types.signature String_map.t ->
+  current:Types.signature String_map.t ->
+  module_ option String_map.t

--- a/lib/library.ml
+++ b/lib/library.ml
@@ -178,20 +178,17 @@ let rec expand_sig ~library_modules sig_ =
       | _ -> Ok item)
     sig_
 
-let load_unwrapped project_path =
+type t = Types.signature String_map.t
+
+let load_unwrapped project_path : (t, string) result =
   let open CCResult.Infix in
   let* library_modules = collect_modules project_path in
   let module_map =
-    String_map.map
-      (fun sig_ ->
-        match expand_sig ~library_modules (Lazy.force sig_) with
-        | Ok expanded_sig -> expanded_sig
-        | Error e -> failwith e)
-      library_modules
+    String_map.map (fun sig_ -> Lazy.force sig_) library_modules
   in
   Ok module_map
 
-let load ~main_module project_path =
+let load ~main_module project_path : (t, string) result =
   let open CCResult.Infix in
   let* library_modules = collect_modules project_path in
   let* main_sig =

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,2 +1,3 @@
 val load_cmi : string -> (Types.signature * string, string) result
-val load : main_module:string -> string -> (Types.signature, string) result
+val load_unwrapped : string -> (Types.signature String_map.t, string) result
+val load : main_module:string -> string -> (Types.signature String_map.t, string) result

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,3 +1,5 @@
 val load_cmi : string -> (Types.signature * string, string) result
 val load_unwrapped : string -> (Types.signature String_map.t, string) result
-val load : main_module:string -> string -> (Types.signature String_map.t, string) result
+
+val load :
+  main_module:string -> string -> (Types.signature String_map.t, string) result

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,5 +1,16 @@
 val load_cmi : string -> (Types.signature * string, string) result
-val load_unwrapped : string -> (Types.signature String_map.t, string) result
 
-val load :
-  main_module:string -> string -> (Types.signature String_map.t, string) result
+type t = Types.signature String_map.t
+(** Type representing a library's root modules.
+    For wrapped libraries, contains only the main module.
+    For unwrapped libraries, contains all root-level modules. *)
+
+val load_unwrapped : string -> (t, string) result
+(** Load an unwrapped library, returning all root-level modules.
+    Each module in the returned map represents a .cmi file at the root
+    of the project path. *)
+
+val load : main_module:string -> string -> (t, string) result
+(** Load a wrapped library, returning only its main module.
+    The returned map will contain a single entry for the main module,
+    with all its dependencies expanded. *)

--- a/tests/api-diff/errors.t
+++ b/tests/api-diff/errors.t
@@ -4,21 +4,33 @@ diff a .cmi file with another .cmi file or a directory with a directory
   $ mkdir test
   $ touch test.cmi
   $ api-diff test test.cmi
-  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
+  api-diff: Arguments must either both be directories or both single .cmi files.
   [123]
 
-When diffing all libraries, the --main-module argument is mandatory
+When diffing all libraries, the Either --main-module or --unwrapped must be specified
 
   $ mkdir test2
   $ api-diff test test2
-  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
+  api-diff: Either --main-module or --unwrapped must be provided when diffing entire libraries.
   [123]
 
-When passing --main-module while diffing single .cmi files, the user will be warn
+When passing --main-module and/or --unwrapped while diffing single .cmi files, the user will be warn
 that it is ignored
 
   $ touch test2.cmi
   $ api-diff --main-module main test.cmi test2.cmi
-  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
+  api-diff: --main-module is ignored when diffing single .cmi files
+  api-diff: Cmi_format.Error(_)
+  [123]
+
+  $ touch test2.cmi
+  $ api-diff --unwrapped main test.cmi test2.cmi
+  api-diff: --unwrapped is ignored when diffing single .cmi files
+  api-diff: Cmi_format.Error(_)
+  [123]
+
+  $ touch test2.cmi
+  $ api-diff --main-module --unwrapped main test.cmi test2.cmi
+  api-diff: --main-module and --unwrapped are ignored when diffing single .cmi files
   api-diff: Cmi_format.Error(_)
   [123]

--- a/tests/api-diff/errors.t
+++ b/tests/api-diff/errors.t
@@ -4,14 +4,14 @@ diff a .cmi file with another .cmi file or a directory with a directory
   $ mkdir test
   $ touch test.cmi
   $ api-diff test test.cmi
-  api-diff: Arguments must either both be directories or both single .cmi files.
+  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
   [123]
 
 When diffing all libraries, the --main-module argument is mandatory
 
   $ mkdir test2
   $ api-diff test test2
-  api-diff: --main-module must be provided when diffing entire libraries.
+  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
   [123]
 
 When passing --main-module while diffing single .cmi files, the user will be warn
@@ -19,6 +19,6 @@ that it is ignored
 
   $ touch test2.cmi
   $ api-diff --main-module main test.cmi test2.cmi
-  api-diff: --main-module ignored when diffing single .cmi files
+  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
   api-diff: Cmi_format.Error(_)
   [123]

--- a/tests/api-diff/errors.t
+++ b/tests/api-diff/errors.t
@@ -24,13 +24,13 @@ that it is ignored
   [123]
 
   $ touch test2.cmi
-  $ api-diff --unwrapped main test.cmi test2.cmi
+  $ api-diff --unwrapped test.cmi test2.cmi
   api-diff: --unwrapped is ignored when diffing single .cmi files
   api-diff: Cmi_format.Error(_)
   [123]
 
   $ touch test2.cmi
-  $ api-diff --main-module --unwrapped main test.cmi test2.cmi
+  $ api-diff --main-module main --unwrapped test.cmi test2.cmi
   api-diff: --main-module and --unwrapped are ignored when diffing single .cmi files
   api-diff: Cmi_format.Error(_)
   [123]

--- a/tests/api-diff/project_comparison.t
+++ b/tests/api-diff/project_comparison.t
@@ -1,3 +1,5 @@
+# Test for wrapped libraries 
+
 Create the first version of a simple project
   $ mkdir -p project_v1/lib
 
@@ -106,6 +108,122 @@ Run the api-diff tool on the two project versions
   +type shape = Square | Circle | Triangle
   
   diff module Mylib.Utils:
+  +val triple : int -> int
+  
+  [1]
+
+
+# Test for unwrapped libraries 
+
+Create the first version of a simple project
+  $ mkdir -p proj_v1/lib
+
+  $ cat > proj_v1/dune-project <<EOF
+  > (lang dune 2.9)
+  > (name myproject)
+  > EOF
+
+  $ cat > proj_v1/lib/dune <<EOF
+  > (library
+  >  (name mylib)
+  >  (wrapped false))
+  > EOF
+
+Create math.ml file with basic math functions and an Advanced module
+  $ cat > proj_v1/lib/math.ml <<EOF
+  > let add x y = x + y
+  > let subtract x y = x - y
+  > module Advanced = struct
+  >   let square x = x * x
+  >   type shape = Square | Circle
+  > end
+  > EOF
+
+Create math.mli interface file
+  $ cat > proj_v1/lib/math.mli <<EOF
+  > val add : int -> int -> int
+  > val subtract : int -> int -> int
+  > module Advanced : sig
+  >   val square : int -> int
+  >   type shape = Square | Circle
+  > end
+  > EOF
+
+Create utils.ml file with a double function
+  $ cat > proj_v1/lib/utils.ml <<EOF
+  > let double x = x * 2
+  > EOF
+
+Create utils.mli interface file
+  $ cat > proj_v1/lib/utils.mli <<EOF
+  > val double : int -> int
+  > EOF
+
+Build the first version
+  $ cd proj_v1 && dune build && cd ..
+
+Create the second version of the same project with some changes
+  $ cp -r proj_v1 proj_v2
+
+Update math.ml in proj_v2 with new functions and modifications
+  $ cat > proj_v2/lib/math.ml <<EOF
+  > let add x y z = x + y + z
+  > let subtract x y = x - y
+  > let multiply x y = x * y
+  > module Advanced = struct
+  >   let square x = x * x
+  >   let cube x = x * x * x
+  >   type shape = Square | Circle | Triangle
+  > end
+  > module New_module = struct
+  >   let hello () = "Hello, World!"
+  > end
+  > EOF
+
+Update math.mli in proj_v2 to reflect changes
+  $ cat > proj_v2/lib/math.mli <<EOF
+  > val add : int -> int -> int -> int
+  > val subtract : int -> int -> int
+  > val multiply : int -> int -> int
+  > module Advanced : sig
+  >   val square : int -> int
+  >   val cube : int -> int
+  >   type shape = Square | Circle | Triangle
+  > end
+  > module New_module : sig
+  >   val hello : unit -> string
+  > end
+  > EOF
+
+Update utils.ml in proj_v2 with a new triple function
+  $ cat > proj_v2/lib/utils.ml <<EOF
+  > let double x = x * 2
+  > let triple x = x * 3
+  > EOF
+
+Update utils.mli in proj_v2 to include the new triple function
+  $ cat > proj_v2/lib/utils.mli <<EOF
+  > val double : int -> int
+  > val triple : int -> int
+  > EOF
+
+Build the second version
+  $ cd proj_v2 && dune build && cd ..
+
+Run the api-diff tool on the two project versions
+  $ api-diff --unwrapped proj_v1/_build/default/lib/.mylib.objs/byte proj_v2/_build/default/lib/.mylib.objs/byte
+  diff module Math:
+  -val add : int -> int -> int
+  +val add : int -> int -> int -> int
+  +val multiply : int -> int -> int
+  +module New_module: sig val hello : unit -> string end
+  
+  diff module Math.Advanced:
+  +val cube : int -> int
+  -type shape = Square | Circle
+  +type shape = Square | Circle | Triangle
+  
+  diff module Utils:
   +val triple : int -> int
   
   [1]


### PR DESCRIPTION
This should eventually resolve #71. 
The following changes will be added incrementally:

- [x] Add a flag for unwrapped libraries in the api-diff CLI tool.
- [x] Add Library.load_unwrapped 

 