### PR TITLE
Improve diff representation for record types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 
 ### Changed
 
+  - Improve diff representation of modified record types (#109, @azzsal)
+
 ### Deprecated
 
 ### Fixed

--- a/lib/diff.ml
+++ b/lib/diff.ml
@@ -104,6 +104,11 @@ let module_type_fallback ~loc ~typing_env ~name ~reference ~current =
   | exception Includemod.Error _ ->
       Some (Module { mname = name; mdiff = Modified Unsupported })
 
+let extract_lbls lbls =
+  List.fold_left
+    (fun map lbl -> String_map.add (Ident.name lbl.ld_id) lbl map)
+    String_map.empty lbls
+
 let rec type_item ~typing_env ~name ~reference ~current =
   match (reference, current) with
   | None, None -> None
@@ -174,11 +179,6 @@ and modified_record_type ~ref_label_lst ~cur_label_lst =
     |> String_map.bindings |> List.map snd
   in
   (common_lbls, changed_lbls)
-
-and extract_lbls lbls =
-  List.fold_left
-    (fun map lbl -> String_map.add (Ident.name lbl.ld_id) lbl map)
-    String_map.empty lbls
 
 let value_item ~typing_env ~name ~reference ~current =
   match (reference, current) with

--- a/lib/diff.ml
+++ b/lib/diff.ml
@@ -12,20 +12,16 @@ type value = {
   vdiff : (value_description, value_description atomic_modification) t;
 }
 
-type 'changed type_modification =
-  | Compound of 'changed list
+type type_modification =
+  | Compound of record_field list
   | Atomic of type_declaration atomic_modification
 
-and label_ = {
+and record_field = {
   lname : string;
   ldiff : (label_declaration, label_declaration atomic_modification) t;
 }
 
-type type_ = {
-  tname : string;
-  tdiff : (type_declaration, label_ type_modification) t;
-}
-
+type type_ = { tname : string; tdiff : (type_declaration, type_modification) t }
 type class_modification = Unsupported
 
 type class_ = {
@@ -144,7 +140,6 @@ let rec type_item ~typing_env ~name ~reference ~current =
                    })))
 
 and modified_record_type ~typing_env ~ref_label_lst ~cur_label_lst =
-  let _ = typing_env in
   let ref_lbls = extract_lbls ref_label_lst in
   let curr_lbls = extract_lbls cur_label_lst in
   let changed_lbls =

--- a/lib/diff.ml
+++ b/lib/diff.ml
@@ -131,7 +131,7 @@ let rec type_item ~typing_env ~name ~reference ~current =
           match (reference.type_kind, current.type_kind) with
           | Type_record (ref_label_lst, _), Type_record (cur_label_lst, _) ->
               let changed_lbls =
-                modified_record_type ~ref_label_lst ~cur_label_lst
+                modified_record_type ~typing_env ~ref_label_lst ~cur_label_lst
               in
               Some
                 (Type { tname = name; tdiff = Modified (Compound changed_lbls) })
@@ -143,7 +143,8 @@ let rec type_item ~typing_env ~name ~reference ~current =
                      tdiff = Modified (Atomic { reference; current });
                    })))
 
-and modified_record_type ~ref_label_lst ~cur_label_lst =
+and modified_record_type ~typing_env ~ref_label_lst ~cur_label_lst =
+  let _ = typing_env in
   let ref_lbls = extract_lbls ref_label_lst in
   let curr_lbls = extract_lbls cur_label_lst in
   let changed_lbls =
@@ -154,7 +155,7 @@ and modified_record_type ~ref_label_lst ~cur_label_lst =
         | Some ref, None -> Some { lname = name; ldiff = Removed ref }
         | None, Some cur -> Some { lname = name; ldiff = Added cur }
         | Some ref, Some cur ->
-            if ref.ld_type = cur.ld_type then None
+            if Ctype.does_match typing_env ref.ld_type cur.ld_type then None
             else
               Some
                 {

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -21,11 +21,11 @@ and cltype = {
   ctdiff : (Types.class_type_declaration, class_type_modification) t;
 }
 
-type 'changed type_modification =
-  | Compound of 'changed list
+type type_modification =
+  | Compound of record_field list
   | Atomic of Types.type_declaration atomic_modification
 
-and label_ = {
+and record_field = {
   lname : string;
   ldiff :
     (Types.label_declaration, Types.label_declaration atomic_modification) t;
@@ -33,7 +33,7 @@ and label_ = {
 
 type type_ = {
   tname : string;
-  tdiff : (Types.type_declaration, label_ type_modification) t;
+  tdiff : (Types.type_declaration, type_modification) t;
 }
 
 type module_ = {

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -21,11 +21,9 @@ and cltype = {
   ctdiff : (Types.class_type_declaration, class_type_modification) t;
 }
 
-type type_modification =
-  | Record of record_modification list
-  | Any of Types.type_declaration atomic_modification
-
-and record_modification = label_
+type ('common, 'changed) type_modification =
+  | Compound of 'common list * 'changed list
+  | Atomic of Types.type_declaration atomic_modification
 
 and label_ = {
   lname : string;
@@ -35,7 +33,10 @@ and label_ = {
 
 type type_ = {
   tname : string;
-  tdiff : (Types.type_declaration, type_modification) t;
+  tdiff :
+    ( Types.type_declaration,
+      (Types.label_declaration, label_) type_modification )
+    t;
 }
 
 type module_ = {

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -21,9 +21,18 @@ and cltype = {
   ctdiff : (Types.class_type_declaration, class_type_modification) t;
 }
 
+type type_modification =
+  | Record of record_modification list
+  | Any of Types.type_declaration atomic_modification
+
+and record_modification =
+  | Added of Ident.t * Types.type_expr
+  | Removed of Ident.t * Types.type_expr
+  | Modified of Ident.t * Types.type_expr * Types.type_expr
+
 type type_ = {
   tname : string;
-  tdiff : (Types.type_declaration, Types.type_declaration atomic_modification) t;
+  tdiff : (Types.type_declaration, type_modification) t;
 }
 
 type module_ = {

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -25,10 +25,13 @@ type type_modification =
   | Record of record_modification list
   | Any of Types.type_declaration atomic_modification
 
-and record_modification =
-  | Added of Ident.t * Types.type_expr
-  | Removed of Ident.t * Types.type_expr
-  | Modified of Ident.t * Types.type_expr * Types.type_expr
+and record_modification = label_
+
+and label_ = {
+  lname : string;
+  ldiff :
+    (Types.label_declaration, Types.label_declaration atomic_modification) t;
+}
 
 type type_ = {
   tname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -21,8 +21,8 @@ and cltype = {
   ctdiff : (Types.class_type_declaration, class_type_modification) t;
 }
 
-type ('common, 'changed) type_modification =
-  | Compound of 'common list * 'changed list
+type 'changed type_modification =
+  | Compound of 'changed list
   | Atomic of Types.type_declaration atomic_modification
 
 and label_ = {
@@ -33,10 +33,7 @@ and label_ = {
 
 type type_ = {
   tname : string;
-  tdiff :
-    ( Types.type_declaration,
-      (Types.label_declaration, label_) type_modification )
-    t;
+  tdiff : (Types.type_declaration, label_ type_modification) t;
 }
 
 type module_ = {

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -82,8 +82,18 @@ let process_diff (diff : (_, _ Diff.atomic_modification) Diff.t) name to_lines =
 let process_value_diff (val_diff : Diff.value) =
   process_diff val_diff.vdiff val_diff.vname vd_to_lines
 
-let process_type_diff (type_diff : Diff.type_) =
-  process_diff type_diff.tdiff type_diff.tname td_to_lines
+exception BadTypeModification of Diff.type_modification
+
+let rec process_type_diff (type_diff : Diff.type_) =
+  let type_diff_with_atomic_mod = convert_modification type_diff.tdiff in
+  process_diff type_diff_with_atomic_mod type_diff.tname td_to_lines
+
+and convert_modification diff =
+  match diff with
+  | Diff.Modified (Record mods) -> raise (BadTypeModification (Record mods))
+  | Diff.Modified (Any mods) -> Diff.Modified mods
+  | Diff.Added td -> Diff.Added td
+  | Diff.Removed td -> Diff.Removed td
 
 let process_class_diff (class_diff : Diff.class_) =
   match class_diff.cdiff with

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -131,10 +131,10 @@ and process_modified_record_type_diff name diff =
   @ List.map (fun c -> indent_lbl c) changes
   @ [ Same "}" ]
 
-and process_changed_labels (lbls_diffs : Diff.label_ list) =
+and process_changed_labels (lbls_diffs : Diff.record_field list) =
   List.flatten
     (List.map
-       (fun (lbl_diff : Diff.label_) -> process_lbl_diff lbl_diff.ldiff)
+       (fun (lbl_diff : Diff.record_field) -> process_lbl_diff lbl_diff.ldiff)
        lbls_diffs)
 
 let process_class_diff (class_diff : Diff.class_) =

--- a/lib/text_diff.mli
+++ b/lib/text_diff.mli
@@ -1,22 +1,18 @@
-(** Utilities for custom diff printing  *)
+(** Utilities for custom diff printing *)
 
-type conflict2 = { orig : string list; new_ : string list }
+type conflict2
 
 type t = conflict2 list String_map.t
 (** Type for representing library interface diffs as text diff.
 
-    Changes are arranged per fully qualified module path.
-    Keys are module path, as strings, that map to the textual diff
-    for the content of said module.
-    
-    The removal or addition of a module is listed under its parent.
-    E.g. if [Main.M] was removed, this will show in the textual diff
-    under the key ["Main"].
-    On the other hand, if [Main.M] is present in both versions but received
-    a new function [Main.M.do_something], this will show in the textual
-    diff under the key ["Main.M"].
-    Identical modules won't appear in the map.
- *)
+    Changes are arranged per fully qualified module path. Keys are module path,
+    as strings, that map to the textual diff for the content of said module.
+
+    The removal or addition of a module is listed under its parent. E.g. if
+    [Main.M] was removed, this will show in the textual diff under the key
+    ["Main"]. On the other hand, if [Main.M] is present in both versions but
+    received a new function [Main.M.do_something], this will show in the textual
+    diff under the key ["Main.M"]. Identical modules won't appear in the map. *)
 
 val pp : Format.formatter -> t -> unit
 (** Pretty-print the text diff in a human readable, git diff like format. *)
@@ -26,6 +22,6 @@ val from_diff : Diff.module_ -> t
 
 module With_colors : sig
   val pp : Format.formatter -> t -> unit
-  (** Same as regular [pp] but prints added lines in green and removed lines
-    in red. *)
+  (** Same as regular [pp] but prints added lines in green and removed lines in
+      red. *)
 end

--- a/lib/text_diff.mli
+++ b/lib/text_diff.mli
@@ -1,8 +1,6 @@
 (** Utilities for custom diff printing *)
 
-type conflict2
-
-type t = conflict2 list String_map.t
+type t
 (** Type for representing library interface diffs as text diff.
 
     Changes are arranged per fully qualified module path. Keys are module path,

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -25,9 +25,7 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi add_field.cmi
   diff module Add_field:
    type student = {
-     first_name : string;
-     id : int option;
-     last_name : string;
+     ...
   +  level : int;
    }
   
@@ -48,8 +46,7 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi remove_field.cmi
   diff module Remove_field:
    type student = {
-     first_name : string;
-     last_name : string;
+     ...
   -  id : int option;
    }
   
@@ -70,8 +67,7 @@ Run api-watcher on the two cmi files
   $ api-diff ref.cmi modify_field_type.cmi
   diff module Modify_field_type:
    type student = {
-     first_name : string;
-     last_name : string;
+     ...
   -  id : int option;
   +  id : int;
    }

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -24,13 +24,13 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_field.cmi
   diff module Add_field:
-  *type student = {
-    first_name: string;
-    last_name: string;
-    id: int option;
-    +level: int
-  }
-
+   type student = {
+     first_name : string;
+     id : int option;
+     last_name : string;
+  +  level : int;
+   }
+  
   [1]
 
 ### Removing a field from a record type:
@@ -47,31 +47,52 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_field.cmi
   diff module Remove_field:
-  *type student = {
-    first_name: string;
-    last_name: string;
-    -id: int option
-  }
+   type student = {
+     first_name : string;
+     last_name : string;
+  -  id : int option;
+   }
+  
+  [1]
 
-### Modifying a field's type in a record type: 
+### Modifying a field's type in a record type:
 
-  $ cat > modify_field_type.mli << EOF 
+  $ cat > modify_field_type.mli << EOF
   > type student = {first_name: string; last_name: string; id: int}
   > EOF
 
 We generate the .cmi file
 
   $ ocamlc modify_field_type.mli << EOF
-  
-Run the api-watcher on the two cmi files
 
-  $ api-diff ref.cmi modify_field_type.cmi 
+Run api-watcher on the two cmi files
+
+  $ api-diff ref.cmi modify_field_type.cmi
   diff module Modify_field_type:
-  *type student = {
-    first_name: string;
-    last_name: string;
-    -id: int option
-    +id: int
-  }
+   type student = {
+     first_name : string;
+     last_name : string;
+  -  id : int option;
+  +  id : int;
+   }
+  
+  [1]
 
+### Modifying a field's type in a record type to a same alias type:
 
+  $ cat > alias_field_type.mli << EOF
+  > type y = int
+  > type student = {first_name: string; last_name: string; id: y}
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc alias_field_type.mli << EOF
+
+Run api-watcher on the two cmi files
+
+  $ api-diff ref.cmi alias_field_type.cmi
+  diff module Alias_field_type:
+  +type y = int
+  
+  [1]

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -77,7 +77,7 @@ Run api-watcher on the two cmi files
 ### Modifying a field's type in a record type to a same alias type:
 
   $ cat > alias_field_type.mli << EOF
-  > type y = int
+  > type y = int option
   > type student = {first_name: string; last_name: string; id: y}
   > EOF
 
@@ -89,6 +89,6 @@ Run api-watcher on the two cmi files
 
   $ api-diff ref.cmi alias_field_type.cmi
   diff module Alias_field_type:
-  +type y = int
+  +type y = int option
   
   [1]

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -1,0 +1,77 @@
+Here we generate a `.mli` file with a record type:
+
+  $ cat > ref.mli << EOF
+  > type student = {first_name: string; last_name: string; id: int option}
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc ref.mli
+
+# Tests for different kind of modifications to a record type:
+
+### Adding a field to a record type:
+
+  $ cat > add_field.mli << EOF
+  > type student = {first_name: string; last_name: string; id: int option; level: int}
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc add_field.mli 
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi add_field.cmi
+  diff module Add_field:
+  *type student = {
+    first_name: string;
+    last_name: string;
+    id: int option;
+    +level: int
+  }
+
+  [1]
+
+### Removing a field from a record type:
+
+  $ cat > remove_field.mli << EOF 
+  > type student = {first_name: string; last_name: string}
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc remove_field.mli 
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi remove_field.cmi
+  diff module Remove_field:
+  *type student = {
+    first_name: string;
+    last_name: string;
+    -id: int option
+  }
+
+### Modifying a field's type in a record type: 
+
+  $ cat > modify_field_type.mli << EOF 
+  > type student = {first_name: string; last_name: string; id: int}
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc modify_field_type.mli << EOF
+  
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi modify_field_type.cmi 
+  diff module Modify_field_type:
+  *type student = {
+    first_name: string;
+    last_name: string;
+    -id: int option
+    +id: int
+  }
+
+


### PR DESCRIPTION
This PR implements a simple initial diff representation for record types. It aims to resolve a part of #108.
The following changes are made to the project:

- [x] Add a new diff representation for record types
- [x] using this representation when diffing record types
- [x] pretty printing the new representation as text (WIP)