### PR TITLE
Add Library.load_unwrapped and make Library.load match it

### DIFF
--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -47,8 +47,10 @@ let run (`Main_module main_module) (`Unwrapped_library unwrapped)
     match curr_mode with
     | Wrapped main_module ->
         let main_module = String.capitalize_ascii main_module in
-        let+ reference_sig = Api_watch.Library.load ~main_module reference
-        and+ current_sig = Api_watch.Library.load ~main_module current in
+        let+ reference_map = Api_watch.Library.load ~main_module reference
+        and+ current_map = Api_watch.Library.load ~main_module current in
+        let reference_sig = Api_watch.String_map.find main_module reference_map in
+        let current_sig = Api_watch.String_map.find main_module current_map in
         let module_name = String.capitalize_ascii main_module in
         (reference_sig, current_sig, module_name)
     | Unwrapped -> failwith "TODO: Call Api_watch.Library.load_unwrapped"

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -49,7 +49,9 @@ let run (`Main_module main_module) (`Unwrapped_library unwrapped)
         let main_module = String.capitalize_ascii main_module in
         let+ reference_map = Api_watch.Library.load ~main_module reference
         and+ current_map = Api_watch.Library.load ~main_module current in
-        let reference_sig = Api_watch.String_map.find main_module reference_map in
+        let reference_sig =
+          Api_watch.String_map.find main_module reference_map
+        in
         let current_sig = Api_watch.String_map.find main_module current_map in
         let module_name = String.capitalize_ascii main_module in
         (reference_sig, current_sig, module_name)

--- a/dev-tools/print_api.ml
+++ b/dev-tools/print_api.ml
@@ -22,7 +22,7 @@ let run (`Main_module main_module) (`Input fn) =
       Ok ()
   | true, Some main_module ->
       let+ sig_map = Api_watch.Library.load ~main_module fn in
-      let sig_ = Api_watch.String_map.find main_module sig_map in 
+      let sig_ = Api_watch.String_map.find main_module sig_map in
       Printtyp.signature Format.std_formatter sig_;
       Format.printf "\n"
 

--- a/dev-tools/print_api.ml
+++ b/dev-tools/print_api.ml
@@ -21,7 +21,8 @@ let run (`Main_module main_module) (`Input fn) =
       List.iter print_cmi cmi_files;
       Ok ()
   | true, Some main_module ->
-      let+ sig_ = Api_watch.Library.load ~main_module fn in
+      let+ sig_map = Api_watch.Library.load ~main_module fn in
+      let sig_ = Api_watch.String_map.find main_module sig_map in 
       Printtyp.signature Format.std_formatter sig_;
       Format.printf "\n"
 

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,2 +1,3 @@
 val load_cmi : string -> (Types.signature * string, string) result
-val load : main_module:string -> string -> (Types.signature, string) result
+val load_unwrapped : string -> (Types.signature String_map.t, string) result
+val load : main_module:string -> string -> (Types.signature String_map.t, string) result

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,3 +1,5 @@
 val load_cmi : string -> (Types.signature * string, string) result
 val load_unwrapped : string -> (Types.signature String_map.t, string) result
-val load : main_module:string -> string -> (Types.signature String_map.t, string) result
+
+val load :
+  main_module:string -> string -> (Types.signature String_map.t, string) result

--- a/tests/api-diff/errors.t
+++ b/tests/api-diff/errors.t
@@ -4,21 +4,33 @@ diff a .cmi file with another .cmi file or a directory with a directory
   $ mkdir test
   $ touch test.cmi
   $ api-diff test test.cmi
-  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
+  api-diff: Arguments must either both be directories or both single .cmi files.
   [123]
 
-When diffing all libraries, the --main-module argument is mandatory
+When diffing all libraries, the Either --main-module or --unwrapped must be specified
 
   $ mkdir test2
   $ api-diff test test2
-  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
+  api-diff: Either --main-module or --unwrapped must be provided when diffing entire libraries.
   [123]
 
-When passing --main-module while diffing single .cmi files, the user will be warn
+When passing --main-module and/or --unwrapped while diffing single .cmi files, the user will be warn
 that it is ignored
 
   $ touch test2.cmi
   $ api-diff --main-module main test.cmi test2.cmi
-  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
+  api-diff: --main-module is ignored when diffing single .cmi files
+  api-diff: Cmi_format.Error(_)
+  [123]
+
+  $ touch test2.cmi
+  $ api-diff --unwrapped main test.cmi test2.cmi
+  api-diff: --unwrapped is ignored when diffing single .cmi files
+  api-diff: Cmi_format.Error(_)
+  [123]
+
+  $ touch test2.cmi
+  $ api-diff --main-module --unwrapped main test.cmi test2.cmi
+  api-diff: --main-module and --unwrapped are ignored when diffing single .cmi files
   api-diff: Cmi_format.Error(_)
   [123]

--- a/tests/api-diff/errors.t
+++ b/tests/api-diff/errors.t
@@ -4,14 +4,14 @@ diff a .cmi file with another .cmi file or a directory with a directory
   $ mkdir test
   $ touch test.cmi
   $ api-diff test test.cmi
-  api-diff: Arguments must either both be directories or both single .cmi files.
+  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
   [123]
 
 When diffing all libraries, the --main-module argument is mandatory
 
   $ mkdir test2
   $ api-diff test test2
-  api-diff: --main-module must be provided when diffing entire libraries.
+  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
   [123]
 
 When passing --main-module while diffing single .cmi files, the user will be warn
@@ -19,6 +19,6 @@ that it is ignored
 
   $ touch test2.cmi
   $ api-diff --main-module main test.cmi test2.cmi
-  api-diff: --main-module ignored when diffing single .cmi files
+  api-diff: Inconsistent arguments. Either --main-module, --unwrapped-library or two single $(b,.cmi) files should be provided.
   api-diff: Cmi_format.Error(_)
   [123]


### PR DESCRIPTION
Fixes a part of #71  

I have made the following changes:

1. Added a `Library.load_unwrapped` function that properly loads an unwrapped lib, returning a `String_map.t` from module name to `Types.signature`.
2. Made Library.load match the above `Types.signature String_map.t` type
3. Modified `Api_diff.run` and `Print_api` to adapt to the new map return type