### PR TITLE
Add type kind to type declaration diff representation

### DIFF
--- a/lib/diff.ml
+++ b/lib/diff.ml
@@ -13,17 +13,12 @@ type value = {
 }
 
 type type_ = { tname : string; tdiff : (type_declaration, type_modification) t }
+and type_modification = { type_kind_mismatch : type_kind_mismatch option }
 
-and type_modification =
-  type_kind_mismatch * type_args_mismatch option * type_param list
-
-and type_kind_mismatch = type_kind * type_kind
-and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
-
-and type_args_mismatch =
+and type_kind_mismatch =
   | Record_mismatch of record_field list
   | Variant_mismatch of constructor_ list
-  | Atomic_mismatch of type_declaration atomic_modification
+  | Atomic_mismatch of type_decl_kind atomic_modification
 
 and record_field = {
   rname : string;
@@ -140,21 +135,13 @@ let rec type_item ~typing_env ~name ~reference ~current =
       Some (Type { tname = name; tdiff = Added current })
   | Some (reference, _), Some (current, _) -> (
       match type_decls ~typing_env ~reference ~current with
-      | (ref_tk, cur_tk), None, [] when ref_tk = cur_tk -> None
-      | (ref_tk, cur_tk), args_diff, type_params ->
-          Some
-            (Type
-               {
-                 tname = name;
-                 tdiff = Modified ((ref_tk, cur_tk), args_diff, type_params);
-               }))
+      | { type_kind_mismatch = None } -> None
+      | { type_kind_mismatch } ->
+          Some (Type { tname = name; tdiff = Modified { type_kind_mismatch } }))
 
 and type_decls ~typing_env ~reference ~current =
-  let type_kind_diff, type_args_diff =
-    type_kind ~typing_env ~reference ~current
-  in
-  let type_params_diff = [] in
-  (type_kind_diff, type_args_diff, type_params_diff)
+  let type_kind_diff = type_kind ~typing_env ~reference ~current in
+  { type_kind_mismatch = type_kind_diff }
 
 and type_kind ~typing_env ~reference ~current =
   match (reference.type_kind, current.type_kind) with
@@ -163,19 +150,8 @@ and type_kind ~typing_env ~reference ~current =
         modified_record_type ~typing_env ~ref_label_lst ~cur_label_lst
       in
       match changed_lbls with
-      | [] -> ((Kind_record, Kind_record), None)
-      | _ -> ((Kind_record, Kind_record), Some (Record_mismatch changed_lbls)))
-  | Type_record _, Type_variant _ ->
-      ( (Kind_record, Kind_variant),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_record _, Type_abstract _ ->
-      ( (Kind_record, Kind_abstract),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_record _, Type_open ->
-      ((Kind_record, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_variant _, Type_record _ ->
-      ( (Kind_variant, Kind_record),
-        Some (Atomic_mismatch { reference; current }) )
+      | [] -> None
+      | _ -> Some (Record_mismatch changed_lbls))
   | Type_variant (ref_constructor_lst, _), Type_variant (cur_constructor_lst, _)
     -> (
       let changed_constrs =
@@ -183,31 +159,13 @@ and type_kind ~typing_env ~reference ~current =
           ~cur_constructor_lst
       in
       match changed_constrs with
-      | [] -> ((Kind_variant, Kind_variant), None)
-      | _ ->
-          ((Kind_variant, Kind_variant), Some (Variant_mismatch changed_constrs))
-      )
-  | Type_variant _, Type_abstract _ ->
-      ( (Kind_variant, Kind_abstract),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_variant _, Type_open ->
-      ((Kind_variant, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_abstract _, Type_record _ ->
-      ( (Kind_abstract, Kind_record),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_abstract _, Type_variant _ ->
-      ( (Kind_abstract, Kind_variant),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_abstract _, Type_abstract _ -> ((Kind_abstract, Kind_abstract), None)
-  | Type_abstract _, Type_open ->
-      ((Kind_abstract, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_record _ ->
-      ((Kind_open, Kind_record), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_variant _ ->
-      ((Kind_open, Kind_variant), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_abstract _ ->
-      ((Kind_open, Kind_abstract), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_open -> ((Kind_open, Kind_open), None)
+      | [] -> None
+      | _ -> Some (Variant_mismatch changed_constrs))
+  | Type_abstract _, Type_abstract _ -> None
+  | Type_open, Type_open -> None
+  | ref_type_kind, cur_type_kind ->
+      Some
+        (Atomic_mismatch { reference = ref_type_kind; current = cur_type_kind })
 
 and modified_variant_type ~typing_env ~ref_constructor_lst ~cur_constructor_lst
     =

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -12,16 +12,12 @@ type type_ = {
   tdiff : (Types.type_declaration, type_modification) t;
 }
 
-and type_modification =
-  type_kind_mismatch * type_args_mismatch option * type_param list
+and type_modification = { type_kind_mismatch : type_kind_mismatch option }
 
-and type_kind_mismatch = type_kind * type_kind
-and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
-
-and type_args_mismatch =
+and type_kind_mismatch =
   | Record_mismatch of record_field list
   | Variant_mismatch of constructor_ list
-  | Atomic_mismatch of Types.type_declaration atomic_modification
+  | Atomic_mismatch of Types.type_decl_kind atomic_modification
 
 and record_field = {
   rname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -13,9 +13,15 @@ type type_ = {
 }
 
 and type_modification =
-  | Record_diff of record_field list
-  | Variant_diff of constructor_ list
-  | Atomic of Types.type_declaration atomic_modification
+  type_kind_mismatch * type_args_mismatch option * type_param list
+
+and type_kind_mismatch = type_kind * type_kind
+and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
+
+and type_args_mismatch =
+  | Record_mismatch of record_field list
+  | Variant_mismatch of constructor_ list
+  | Atomic_mismatch of Types.type_declaration atomic_modification
 
 and record_field = {
   rname : string;
@@ -37,6 +43,12 @@ and tuple_component =
   ( Types.type_expr,
     (Types.type_expr, Types.type_expr atomic_modification) t )
   Either.t
+
+and type_param = (Types.type_expr, type_param_diff) Either.t
+
+and type_param_diff =
+  | Added_tp of Types.type_expr
+  | Removed_tp of Types.type_expr
 
 type class_ = {
   cname : string;

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -119,19 +119,20 @@ let process_atomic_diff (diff : (_, _ Diff.atomic_modification) Diff.t) name
 
 let rec process_type_diff (type_diff : Diff.type_) =
   match type_diff.tdiff with
-  | Diff.Modified (Record_diff change_lst) ->
+  | Diff.Modified (_, Some (Record_mismatch change_lst), _) ->
       Same ("type " ^ type_diff.tname ^ " = {")
       :: process_modified_record_type_diff ~indent_n:2 change_lst
       @ [ Same "}" ]
-  | Diff.Modified (Variant_diff change_lst) ->
+  | Diff.Modified (_, Some (Variant_mismatch change_lst), _) ->
       Same ("type " ^ type_diff.tname ^ " =")
       :: process_modified_variant_type_diff change_lst
-  | Diff.Modified (Atomic mods) ->
+  | Diff.Modified (_, Some (Atomic_mismatch mods), _) ->
       process_atomic_diff (Diff.Modified mods) type_diff.tname td_to_lines
   | Diff.Added td ->
       process_atomic_diff (Diff.Added td) type_diff.tname td_to_lines
   | Diff.Removed td ->
       process_atomic_diff (Diff.Removed td) type_diff.tname td_to_lines
+  | _ -> assert false
 
 and process_modified_record_type_diff ~indent_n diff =
   let changes = process_modified_labels diff in


### PR DESCRIPTION
This should resolve #114.

The PR will have the following changes:

- Change the type declaration diff representation to be a record type, the only current field now the `type_kind_mismatch`
- Update the Text_diff module accordingly 
- New cram tests to test the above