### PR TITLE
Add type kind, privacy and manifest to type declaration diff representation

### DIFF
--- a/lib/diff.ml
+++ b/lib/diff.ml
@@ -13,17 +13,12 @@ type value = {
 }
 
 type type_ = { tname : string; tdiff : (type_declaration, type_modification) t }
+and type_modification = { type_kind_mismatch : type_kind_mismatch option }
 
-and type_modification =
-  type_kind_mismatch * type_args_mismatch option * type_param list
-
-and type_kind_mismatch = type_kind * type_kind
-and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
-
-and type_args_mismatch =
+and type_kind_mismatch =
   | Record_mismatch of record_field list
   | Variant_mismatch of constructor_ list
-  | Atomic_mismatch of type_declaration atomic_modification
+  | Atomic_mismatch of type_decl_kind atomic_modification
 
 and record_field = {
   rname : string;
@@ -140,21 +135,13 @@ let rec type_item ~typing_env ~name ~reference ~current =
       Some (Type { tname = name; tdiff = Added current })
   | Some (reference, _), Some (current, _) -> (
       match type_decls ~typing_env ~reference ~current with
-      | (ref_tk, cur_tk), None, [] when ref_tk = cur_tk -> None
-      | (ref_tk, cur_tk), args_diff, type_params ->
-          Some
-            (Type
-               {
-                 tname = name;
-                 tdiff = Modified ((ref_tk, cur_tk), args_diff, type_params);
-               }))
+      | { type_kind_mismatch = None } -> None
+      | { type_kind_mismatch } ->
+          Some (Type { tname = name; tdiff = Modified { type_kind_mismatch } }))
 
 and type_decls ~typing_env ~reference ~current =
-  let type_kind_diff, type_args_diff =
-    type_kind ~typing_env ~reference ~current
-  in
-  let type_params_diff = [] in
-  (type_kind_diff, type_args_diff, type_params_diff)
+  let type_kind_diff = type_kind ~typing_env ~reference ~current in
+  { type_kind_mismatch = type_kind_diff }
 
 and type_kind ~typing_env ~reference ~current =
   match (reference.type_kind, current.type_kind) with
@@ -163,19 +150,8 @@ and type_kind ~typing_env ~reference ~current =
         modified_record_type ~typing_env ~ref_label_lst ~cur_label_lst
       in
       match changed_lbls with
-      | [] -> ((Kind_record, Kind_record), None)
-      | _ -> ((Kind_record, Kind_record), Some (Record_mismatch changed_lbls)))
-  | Type_record _, Type_variant _ ->
-      ( (Kind_record, Kind_variant),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_record _, Type_abstract _ ->
-      ( (Kind_record, Kind_abstract),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_record _, Type_open ->
-      ((Kind_record, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_variant _, Type_record _ ->
-      ( (Kind_variant, Kind_record),
-        Some (Atomic_mismatch { reference; current }) )
+      | [] -> None
+      | _ -> Some (Record_mismatch changed_lbls))
   | Type_variant (ref_constructor_lst, _), Type_variant (cur_constructor_lst, _)
     -> (
       let changed_constrs =
@@ -183,31 +159,13 @@ and type_kind ~typing_env ~reference ~current =
           ~cur_constructor_lst
       in
       match changed_constrs with
-      | [] -> ((Kind_variant, Kind_variant), None)
-      | _ ->
-          ((Kind_variant, Kind_variant), Some (Variant_mismatch changed_constrs))
-      )
-  | Type_variant _, Type_abstract _ ->
-      ( (Kind_variant, Kind_abstract),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_variant _, Type_open ->
-      ((Kind_variant, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_abstract _, Type_record _ ->
-      ( (Kind_abstract, Kind_record),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_abstract _, Type_variant _ ->
-      ( (Kind_abstract, Kind_variant),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_abstract _, Type_abstract _ -> ((Kind_abstract, Kind_abstract), None)
-  | Type_abstract _, Type_open ->
-      ((Kind_abstract, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_record _ ->
-      ((Kind_open, Kind_record), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_variant _ ->
-      ((Kind_open, Kind_variant), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_abstract _ ->
-      ((Kind_open, Kind_abstract), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_open -> ((Kind_open, Kind_open), None)
+      | [] -> None
+      | _ -> Some (Variant_mismatch changed_constrs))
+  | Type_abstract _, Type_abstract _ -> None
+  | Type_open, Type_open -> None
+  | ref_type_kind, cur_type_kind ->
+      Some
+        (Atomic_mismatch { reference = ref_type_kind; current = cur_type_kind })
 
 and modified_variant_type ~typing_env ~ref_constructor_lst ~cur_constructor_lst
     =

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -12,7 +12,9 @@ type type_ = {
   tdiff : (Types.type_declaration, type_modification) t;
 }
 
-and type_modification = { type_kind_mismatch : type_kind_mismatch option }
+and type_modification =
+  | Compound_tm of { type_kind_mismatch : type_kind_mismatch option }
+  | Atomic_tm of Types.type_declaration atomic_modification
 
 and type_kind_mismatch =
   | Record_mismatch of record_field list

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -14,12 +14,13 @@ type type_ = {
 
 and type_modification =
   | Compound_tm of {
-    type_kind_mismatch : type_kind_mismatch option;
-    type_privacy_mismatch :
+      type_kind_mismatch : type_kind_mismatch option;
+      type_privacy_mismatch :
         (Asttypes.private_flag, type_privacy_diff) Either.t;
-   type_manifest_mismatch :
-    ( Types.type_expr option,
-      (Types.type_expr, Types.type_expr atomic_modification) t ) Either.t;
+      type_manifest_mismatch :
+        ( Types.type_expr option,
+          (Types.type_expr, Types.type_expr atomic_modification) t )
+        Either.t;
     }
   | Atomic_tm of Types.type_declaration atomic_modification
 

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -12,16 +12,12 @@ type type_ = {
   tdiff : (Types.type_declaration, type_modification) t;
 }
 
-and type_modification =
-  type_kind_mismatch * type_args_mismatch option * type_param list
+and type_modification = { type_kind_mismatch : type_kind_mismatch option }
 
-and type_kind_mismatch = type_kind * type_kind
-and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
-
-and type_args_mismatch =
+and type_kind_mismatch =
   | Record_mismatch of record_field list
   | Variant_mismatch of constructor_ list
-  | Atomic_mismatch of Types.type_declaration atomic_modification
+  | Atomic_mismatch of Types.type_decl_kind atomic_modification
 
 and record_field = {
   rname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -13,9 +13,15 @@ type type_ = {
 }
 
 and type_modification =
-  | Record_diff of record_field list
-  | Variant_diff of constructor_ list
-  | Atomic of Types.type_declaration atomic_modification
+  type_kind_mismatch * type_args_mismatch option * type_param list
+
+and type_kind_mismatch = type_kind * type_kind
+and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
+
+and type_args_mismatch =
+  | Record_mismatch of record_field list
+  | Variant_mismatch of constructor_ list
+  | Atomic_mismatch of Types.type_declaration atomic_modification
 
 and record_field = {
   rname : string;
@@ -37,6 +43,12 @@ and tuple_component =
   ( Types.type_expr,
     (Types.type_expr, Types.type_expr atomic_modification) t )
   Either.t
+
+and type_param = (Types.type_expr, type_param_diff) Either.t
+
+and type_param_diff =
+  | Added_tp of Types.type_expr
+  | Removed_tp of Types.type_expr
 
 type class_ = {
   cname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -14,9 +14,12 @@ type type_ = {
 
 and type_modification =
   | Compound_tm of {
-      type_kind_mismatch : type_kind_mismatch option;
-      type_privacy_mismatch :
+    type_kind_mismatch : type_kind_mismatch option;
+    type_privacy_mismatch :
         (Asttypes.private_flag, type_privacy_diff) Either.t;
+   type_manifest_mismatch :
+    ( Types.type_expr option,
+      (Types.type_expr, Types.type_expr atomic_modification) t ) Either.t;
     }
   | Atomic_tm of Types.type_declaration atomic_modification
 

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -13,8 +13,16 @@ type type_ = {
 }
 
 and type_modification =
-  | Compound_tm of { type_kind_mismatch : type_kind_mismatch option }
+  | Compound_tm of {
+      type_kind_mismatch : type_kind_mismatch option;
+      type_privacy_mismatch :
+        (Asttypes.private_flag, type_privacy_diff) Either.t;
+    }
   | Atomic_tm of Types.type_declaration atomic_modification
+
+and type_privacy_diff =
+  | Added_p of Asttypes.private_flag
+  | Removed_p of Asttypes.private_flag
 
 and type_kind_mismatch =
   | Record_mismatch of record_field list

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -133,16 +133,24 @@ let process_atomic_diff (diff : (_, _ Diff.atomic_modification) Diff.t) name
 
 let rec process_type_diff (type_diff : Diff.type_) =
   match type_diff.tdiff with
-  | Diff.Modified { type_kind_mismatch = Some (Record_mismatch change_lst) } ->
+  | Diff.Modified
+      (Compound_tm { type_kind_mismatch = Some (Record_mismatch change_lst) })
+    ->
       Same ("type " ^ type_diff.tname ^ " = {")
       :: process_modified_record_type_diff ~indent_n:2 change_lst
       @ [ Same "}" ]
-  | Diff.Modified { type_kind_mismatch = Some (Variant_mismatch change_lst) } ->
+  | Diff.Modified
+      (Compound_tm { type_kind_mismatch = Some (Variant_mismatch change_lst) })
+    ->
       Same ("type " ^ type_diff.tname ^ " =")
       :: process_modified_variant_type_diff change_lst
   | Diff.Modified
-      { type_kind_mismatch = Some (Atomic_mismatch { reference; current }) } ->
+      (Compound_tm
+        { type_kind_mismatch = Some (Atomic_mismatch { reference; current }) })
+    ->
       process_atomic_type_kind_diff type_diff.tname reference current
+  | Diff.Modified (Atomic_tm mods) ->
+      process_atomic_diff (Diff.Modified mods) type_diff.tname td_to_lines
   | Diff.Added td ->
       process_atomic_diff (Diff.Added td) type_diff.tname td_to_lines
   | Diff.Removed td ->

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -119,19 +119,20 @@ let process_atomic_diff (diff : (_, _ Diff.atomic_modification) Diff.t) name
 
 let rec process_type_diff (type_diff : Diff.type_) =
   match type_diff.tdiff with
-  | Diff.Modified (Record_diff change_lst) ->
+  | Diff.Modified (_, Some (Record_mismatch change_lst), _) ->
       Same ("type " ^ type_diff.tname ^ " = {")
       :: process_modified_record_type_diff ~indent_n:2 change_lst
       @ [ Same "}" ]
-  | Diff.Modified (Variant_diff change_lst) ->
+  | Diff.Modified (_, Some (Variant_mismatch change_lst), _) ->
       Same ("type " ^ type_diff.tname ^ " =")
       :: process_modified_variant_type_diff change_lst
-  | Diff.Modified (Atomic mods) ->
+  | Diff.Modified (_, Some (Atomic_mismatch mods), _) ->
       process_atomic_diff (Diff.Modified mods) type_diff.tname td_to_lines
   | Diff.Added td ->
       process_atomic_diff (Diff.Added td) type_diff.tname td_to_lines
   | Diff.Removed td ->
       process_atomic_diff (Diff.Removed td) type_diff.tname td_to_lines
+  | _ -> assert false
 
 and process_modified_record_type_diff ~indent_n diff =
   let changes = process_modified_labels diff in

--- a/tests/api-diff/modified_variant_type_tests.t
+++ b/tests/api-diff/modified_variant_type_tests.t
@@ -24,7 +24,7 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_constructor.cmi
   diff module Add_constructor:
-   type rank =
+   type rank = 
     ...
   + | Jack
   

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -1,0 +1,68 @@
+Here we generate `.mli` files for testing the changes in the type kinds
+
+# A .mli file with a record type
+
+  $ cat > ref_record_kind.mli << EOF
+  > type t = { a: int; b: float }
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc ref_record_kind.mli
+
+### A file with a variant type:
+
+  $ cat > cur_variant_kind.mli << EOF
+  > type t = A of int | B of string
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc cur_variant_kind.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref_record_kind.cmi cur_variant_kind.cmi
+  diff module Cur_variant_kind:
+  -type t = { a : int; ; b : float; }
+  +type t = A of int | B of string
+
+  [1]
+
+### A file with an abstract type:
+
+  $ cat > cur_abstract_kind.mli << EOF
+  > type t
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc cur_abstract_kind.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref_record_kind.cmi cur_abstract_kind.cmi
+  diff module Cur_abstract_kind:
+  -type t = { a : int; b : float }
+  +type t
+
+  [1]
+
+### A file with an open type:
+
+  $ cat > cur_open_kind.mli << EOF
+  > type t = ..
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc cur_open_kind.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref_record_kind.cmi cur_open_kind.cmi
+  diff module Cur_open_kind:
+  -type t = { a : int; b : float }
+  +type t = ..
+
+  [1]

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -1,6 +1,6 @@
-Here we generate `.mli` files for testing the changes in the type kinds
+Here we generate files for testing the changes in the type kinds
 
-# A .mli file with a record type
+# A `.mli` file with a record type
 
   $ cat > ref_record_kind.mli << EOF
   > type t = { a: int; b: float }
@@ -10,59 +10,67 @@ We generate the .cmi file
 
   $ ocamlc ref_record_kind.mli
 
-### A file with a variant type:
+### A `.mli` file with a variant type:
 
-  $ cat > cur_variant_kind.mli << EOF
+  $ cat > ref_variant_kind.mli << EOF
   > type t = A of int | B of string
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc cur_variant_kind.mli
+  $ ocamlc ref_variant_kind.mli
 
-Run the api-watcher on the two cmi files
+### A `.mli` file with an abstract type:
 
-  $ api-diff ref_record_kind.cmi cur_variant_kind.cmi
-  diff module Cur_variant_kind:
-  -type t = { a : int; ; b : float; }
-  +type t = A of int | B of string
-
-  [1]
-
-### A file with an abstract type:
-
-  $ cat > cur_abstract_kind.mli << EOF
+  $ cat > ref_abstract_kind.mli << EOF
   > type t
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc cur_abstract_kind.mli
+  $ ocamlc ref_abstract_kind.mli
 
-Run the api-watcher on the two cmi files
+### A `.mli` file with an open type:
 
-  $ api-diff ref_record_kind.cmi cur_abstract_kind.cmi
-  diff module Cur_abstract_kind:
-  -type t = { a : int; b : float }
-  +type t
-
-  [1]
-
-### A file with an open type:
-
-  $ cat > cur_open_kind.mli << EOF
+  $ cat > ref_open_kind.mli << EOF
   > type t = ..
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc cur_open_kind.mli
+  $ ocamlc ref_open_kind.mli
 
-Run the api-watcher on the two cmi files
+Run the api-watcher on record and varient type kinds cmi files
 
-  $ api-diff ref_record_kind.cmi cur_open_kind.cmi
-  diff module Cur_open_kind:
-  -type t = { a : int; b : float }
-  +type t = ..
-
+  $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
+  diff module Ref_variant_kind:
+  -type t = { a : int; ; b : float; }
+  +type t = A of int | B of string
+  
   [1]
+
+Run the api-watcher on record and abstract type kinds cmi files
+
+  $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
+  diff module Ref_abstract_kind:
+  -type t = { a : int; ; b : float; }
+  +type t
+  
+  [1]
+
+Run the api-watcher on record and open type kinds cmi files
+
+  $ api-diff ref_record_kind.cmi ref_open_kind.cmi
+  diff module Ref_open_kind:
+  -type t = { a : int; ; b : float; }
+  +type t = ..
+  
+  [1]
+
+Run the api-watcher on two abstract type kinds cmi files
+
+  $ api-diff ref_abstract_kind.cmi ref_abstract_kind.cmi
+
+Run the api-watcher on two open type kinds cmi files
+
+  $ api-diff ref_open_kind.cmi ref_open_kind.cmi

--- a/tests/api-diff/type_manifest_tests.t
+++ b/tests/api-diff/type_manifest_tests.t
@@ -1,0 +1,25 @@
+Here we generate a `.mli` file to test the changes in the type manifest
+
+  $ cat > ref.mli << EOF
+  > type t
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc ref.mli
+
+### Adding a type manifest
+
+  $ cat > add_manifest.mli << EOF
+  > type t = int list
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc add_manifest.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi add_manifest.cmi
+  diff module Add_manifest:
+  type t = +int list

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -1,0 +1,25 @@
+Here we generate a `.mli` file with a private type abbreviation
+
+  $ cat > ref.mli << EOF
+  > type t = private int
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc ref.mli
+
+# Removing a private type abbreviation from a type declaration
+
+  $ cat > remove_private.mli << EOF
+  > type t = int
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc remove_private.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi remove_private.cmi
+  diff module Remove_private:
+  type t = -private int

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -1,7 +1,7 @@
 Here we generate a `.mli` file with a private type abbreviation
 
   $ cat > ref.mli << EOF
-  > type t = private int
+  > type t = private { a : int; b : float }
   > EOF
 
 We generate the .cmi file
@@ -11,7 +11,7 @@ We generate the .cmi file
 # Removing a private type abbreviation from a type declaration
 
   $ cat > remove_private.mli << EOF
-  > type t = int
+  > type t = { a : int; b : float }
   > EOF
 
 We generate the .cmi file
@@ -22,4 +22,29 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_private.cmi
   diff module Remove_private:
-  type t = -private int
+   type t = -private ....
+  
+  [1]
+
+# Removing a private type abbreviation from a type declaration and modifying record fields
+
+  $ cat > remove_private_modify_record.mli << EOF
+  > type t = { a : float }
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc remove_private_modify_record.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi remove_private_modify_record.cmi
+  diff module Remove_private_modify_record:
+   type t = -private {
+     ...
+  -  a : int;
+  +  a : float;
+  -  b : float;
+   }
+  
+  [1]


### PR DESCRIPTION
This should resolve #114, #115 and #116.

The PR will have the following changes:

- [x] Update the type declaration diff representation to be a record type, having type_kind, type_privacy and type_manifest diffs
- [ ] Update the Text_diff module accordingly
- [ ] New cram tests to test the above