### PR TITLE
Add type kind,  privacy and manifest changes to type declaration diff representation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
   - Improve diff representation of modified record types (#109, @azzsal)
   - Improve diff representation of modified variant types (#111, @azzsal)
+  - Improve the diff representation of type declarations with more fine grained diffing of
+    type kind, type privacy and type manifest (#120, @azzsal)
 
 ### Deprecated
 

--- a/lib/diff.ml
+++ b/lib/diff.ml
@@ -13,17 +13,12 @@ type value = {
 }
 
 type type_ = { tname : string; tdiff : (type_declaration, type_modification) t }
+and type_modification = { type_kind_mismatch : type_kind_mismatch option }
 
-and type_modification =
-  type_kind_mismatch * type_args_mismatch option * type_param list
-
-and type_kind_mismatch = type_kind * type_kind
-and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
-
-and type_args_mismatch =
+and type_kind_mismatch =
   | Record_mismatch of record_field list
   | Variant_mismatch of constructor_ list
-  | Atomic_mismatch of type_declaration atomic_modification
+  | Atomic_mismatch of type_decl_kind atomic_modification
 
 and record_field = {
   rname : string;
@@ -140,21 +135,13 @@ let rec type_item ~typing_env ~name ~reference ~current =
       Some (Type { tname = name; tdiff = Added current })
   | Some (reference, _), Some (current, _) -> (
       match type_decls ~typing_env ~reference ~current with
-      | (ref_tk, cur_tk), None, [] when ref_tk = cur_tk -> None
-      | (ref_tk, cur_tk), args_diff, type_params ->
-          Some
-            (Type
-               {
-                 tname = name;
-                 tdiff = Modified ((ref_tk, cur_tk), args_diff, type_params);
-               }))
+      | { type_kind_mismatch = None } -> None
+      | { type_kind_mismatch } ->
+          Some (Type { tname = name; tdiff = Modified { type_kind_mismatch } }))
 
 and type_decls ~typing_env ~reference ~current =
-  let type_kind_diff, type_args_diff =
-    type_kind ~typing_env ~reference ~current
-  in
-  let type_params_diff = [] in
-  (type_kind_diff, type_args_diff, type_params_diff)
+  let type_kind_diff = type_kind ~typing_env ~reference ~current in
+  { type_kind_mismatch = type_kind_diff }
 
 and type_kind ~typing_env ~reference ~current =
   match (reference.type_kind, current.type_kind) with
@@ -163,19 +150,8 @@ and type_kind ~typing_env ~reference ~current =
         modified_record_type ~typing_env ~ref_label_lst ~cur_label_lst
       in
       match changed_lbls with
-      | [] -> ((Kind_record, Kind_record), None)
-      | _ -> ((Kind_record, Kind_record), Some (Record_mismatch changed_lbls)))
-  | Type_record _, Type_variant _ ->
-      ( (Kind_record, Kind_variant),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_record _, Type_abstract _ ->
-      ( (Kind_record, Kind_abstract),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_record _, Type_open ->
-      ((Kind_record, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_variant _, Type_record _ ->
-      ( (Kind_variant, Kind_record),
-        Some (Atomic_mismatch { reference; current }) )
+      | [] -> None
+      | _ -> Some (Record_mismatch changed_lbls))
   | Type_variant (ref_constructor_lst, _), Type_variant (cur_constructor_lst, _)
     -> (
       let changed_constrs =
@@ -183,31 +159,13 @@ and type_kind ~typing_env ~reference ~current =
           ~cur_constructor_lst
       in
       match changed_constrs with
-      | [] -> ((Kind_variant, Kind_variant), None)
-      | _ ->
-          ((Kind_variant, Kind_variant), Some (Variant_mismatch changed_constrs))
-      )
-  | Type_variant _, Type_abstract _ ->
-      ( (Kind_variant, Kind_abstract),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_variant _, Type_open ->
-      ((Kind_variant, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_abstract _, Type_record _ ->
-      ( (Kind_abstract, Kind_record),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_abstract _, Type_variant _ ->
-      ( (Kind_abstract, Kind_variant),
-        Some (Atomic_mismatch { reference; current }) )
-  | Type_abstract _, Type_abstract _ -> ((Kind_abstract, Kind_abstract), None)
-  | Type_abstract _, Type_open ->
-      ((Kind_abstract, Kind_open), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_record _ ->
-      ((Kind_open, Kind_record), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_variant _ ->
-      ((Kind_open, Kind_variant), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_abstract _ ->
-      ((Kind_open, Kind_abstract), Some (Atomic_mismatch { reference; current }))
-  | Type_open, Type_open -> ((Kind_open, Kind_open), None)
+      | [] -> None
+      | _ -> Some (Variant_mismatch changed_constrs))
+  | Type_abstract _, Type_abstract _ -> None
+  | Type_open, Type_open -> None
+  | ref_type_kind, cur_type_kind ->
+      Some
+        (Atomic_mismatch { reference = ref_type_kind; current = cur_type_kind })
 
 and modified_variant_type ~typing_env ~ref_constructor_lst ~cur_constructor_lst
     =

--- a/lib/diff.ml
+++ b/lib/diff.ml
@@ -18,7 +18,9 @@ and type_modification = {
   type_kind : (Types.type_decl_kind, type_kind) maybe_changed;
   type_privacy : (Asttypes.private_flag, type_privacy) maybe_changed;
   type_manifest :
-    (type_expr option, (type_expr, type_expr atomic_modification) t) maybe_changed;
+    ( type_expr option,
+      (type_expr, type_expr atomic_modification) t )
+    maybe_changed;
 }
 
 and ('same, 'different) maybe_changed =
@@ -163,11 +165,7 @@ and type_decls ~typing_env ~name ~reference ~current =
       ~cur_type_manifest:current.type_manifest
   in
   match { type_kind; type_privacy; type_manifest } with
-  | {
-   type_kind = Same _;
-   type_privacy = Same _;
-   type_manifest = Same _;
-  } ->
+  | { type_kind = Same _; type_privacy = Same _; type_manifest = Same _ } ->
       None
   | diff -> Some (Type { tname = name; tdiff = Modified diff })
 
@@ -199,7 +197,8 @@ and type_kind ~typing_env ~ref_type_kind ~cur_type_kind =
   | (Type_abstract _ as td), Type_abstract _ -> Same td
   | (Type_open as td), Type_open -> Same td
   | ref_type_kind, cur_type_kind ->
-      Different (Atomic_tk { reference = ref_type_kind; current = cur_type_kind })
+      Different
+        (Atomic_tk { reference = ref_type_kind; current = cur_type_kind })
 
 and type_manifest ~typing_env ~ref_type_manifest ~cur_type_manifest =
   match (ref_type_manifest, cur_type_manifest) with
@@ -219,8 +218,7 @@ and modified_variant_type ~typing_env ~ref_constructor_lst ~cur_constructor_lst
         let tuple_diff = modified_tuple_type ~typing_env type_lst1 type_lst2 in
         if
           List.for_all
-            (fun t ->
-              match t with Same _ -> true | Different _ -> false)
+            (fun t -> match t with Same _ -> true | Different _ -> false)
             tuple_diff
         then None
         else Some { csname = name; csdiff = Modified (Tuple_c tuple_diff) }

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -12,7 +12,9 @@ type type_ = {
   tdiff : (Types.type_declaration, type_modification) t;
 }
 
-and type_modification = { type_kind_mismatch : type_kind_mismatch option }
+and type_modification =
+  | Compound_tm of { type_kind_mismatch : type_kind_mismatch option }
+  | Atomic_tm of Types.type_declaration atomic_modification
 
 and type_kind_mismatch =
   | Record_mismatch of record_field list

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -12,17 +12,14 @@ type type_ = {
   tdiff : (Types.type_declaration, type_modification) t;
 }
 
-and type_modification =
-  | Compound_tm of {
-      type_kind_mismatch : type_kind_mismatch option;
-      type_privacy_mismatch :
-        (Asttypes.private_flag, type_privacy_diff) Either.t;
-      type_manifest_mismatch :
-        ( Types.type_expr option,
-          (Types.type_expr, Types.type_expr atomic_modification) t )
-        Either.t;
-    }
-  | Atomic_tm of Types.type_declaration atomic_modification
+and type_modification = {
+  type_kind_mismatch : type_kind_mismatch option;
+  type_privacy_mismatch : (Asttypes.private_flag, type_privacy_diff) Either.t;
+  type_manifest_mismatch :
+    ( Types.type_expr option,
+      (Types.type_expr, Types.type_expr atomic_modification) t )
+    Either.t;
+}
 
 and type_privacy_diff =
   | Added_p of Asttypes.private_flag

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -14,12 +14,13 @@ type type_ = {
 
 and type_modification =
   | Compound_tm of {
-    type_kind_mismatch : type_kind_mismatch option;
-    type_privacy_mismatch :
+      type_kind_mismatch : type_kind_mismatch option;
+      type_privacy_mismatch :
         (Asttypes.private_flag, type_privacy_diff) Either.t;
-   type_manifest_mismatch :
-    ( Types.type_expr option,
-      (Types.type_expr, Types.type_expr atomic_modification) t ) Either.t;
+      type_manifest_mismatch :
+        ( Types.type_expr option,
+          (Types.type_expr, Types.type_expr atomic_modification) t )
+        Either.t;
     }
   | Atomic_tm of Types.type_declaration atomic_modification
 

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -13,22 +13,22 @@ type type_ = {
 }
 
 and type_modification = {
-  type_kind_mismatch : type_kind_mismatch option;
-  type_privacy_mismatch : (Asttypes.private_flag, type_privacy_diff) Either.t;
-  type_manifest_mismatch :
+  type_kind : type_kind option;
+  type_privacy : (Asttypes.private_flag, type_privacy) Either.t;
+  type_manifest :
     ( Types.type_expr option,
       (Types.type_expr, Types.type_expr atomic_modification) t )
     Either.t;
 }
 
-and type_privacy_diff =
-  | Added_p of Asttypes.private_flag
-  | Removed_p of Asttypes.private_flag
+and type_privacy =
+  | Added_p
+  | Removed_p
 
-and type_kind_mismatch =
-  | Record_mismatch of record_field list
-  | Variant_mismatch of constructor_ list
-  | Atomic_mismatch of Types.type_decl_kind atomic_modification
+and type_kind =
+  | Record_tk of record_field list
+  | Variant_tk of constructor_ list
+  | Atomic_tk of Types.type_decl_kind atomic_modification
 
 and record_field = {
   rname : string;
@@ -50,12 +50,6 @@ and tuple_component =
   ( Types.type_expr,
     (Types.type_expr, Types.type_expr atomic_modification) t )
   Either.t
-
-and type_param = (Types.type_expr, type_param_diff) Either.t
-
-and type_param_diff =
-  | Added_tp of Types.type_expr
-  | Removed_tp of Types.type_expr
 
 type class_ = {
   cname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -51,7 +51,7 @@ and constructor_modification =
 and tuple_component =
   ( Types.type_expr,
     (Types.type_expr, Types.type_expr atomic_modification) t )
-  maybe_changed 
+  maybe_changed
 
 type class_ = {
   cname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -12,16 +12,12 @@ type type_ = {
   tdiff : (Types.type_declaration, type_modification) t;
 }
 
-and type_modification =
-  type_kind_mismatch * type_args_mismatch option * type_param list
+and type_modification = { type_kind_mismatch : type_kind_mismatch option }
 
-and type_kind_mismatch = type_kind * type_kind
-and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
-
-and type_args_mismatch =
+and type_kind_mismatch =
   | Record_mismatch of record_field list
   | Variant_mismatch of constructor_ list
-  | Atomic_mismatch of Types.type_declaration atomic_modification
+  | Atomic_mismatch of Types.type_decl_kind atomic_modification
 
 and record_field = {
   rname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -13,13 +13,17 @@ type type_ = {
 }
 
 and type_modification = {
-  type_kind : (Types.type_decl_kind, type_kind) Either.t;
-  type_privacy : (Asttypes.private_flag, type_privacy) Either.t;
+  type_kind : (Types.type_decl_kind, type_kind) maybe_changed;
+  type_privacy : (Asttypes.private_flag, type_privacy) maybe_changed;
   type_manifest :
     ( Types.type_expr option,
       (Types.type_expr, Types.type_expr atomic_modification) t )
-    Either.t;
+    maybe_changed;
 }
+
+and ('same, 'different) maybe_changed =
+  | Same of 'same
+  | Different of 'different
 
 and type_privacy = Added_p | Removed_p
 
@@ -47,7 +51,7 @@ and constructor_modification =
 and tuple_component =
   ( Types.type_expr,
     (Types.type_expr, Types.type_expr atomic_modification) t )
-  Either.t
+  maybe_changed 
 
 type class_ = {
   cname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -13,9 +13,15 @@ type type_ = {
 }
 
 and type_modification =
-  | Record_diff of record_field list
-  | Variant_diff of constructor_ list
-  | Atomic of Types.type_declaration atomic_modification
+  type_kind_mismatch * type_args_mismatch option * type_param list
+
+and type_kind_mismatch = type_kind * type_kind
+and type_kind = Kind_record | Kind_variant | Kind_abstract | Kind_open
+
+and type_args_mismatch =
+  | Record_mismatch of record_field list
+  | Variant_mismatch of constructor_ list
+  | Atomic_mismatch of Types.type_declaration atomic_modification
 
 and record_field = {
   rname : string;
@@ -37,6 +43,12 @@ and tuple_component =
   ( Types.type_expr,
     (Types.type_expr, Types.type_expr atomic_modification) t )
   Either.t
+
+and type_param = (Types.type_expr, type_param_diff) Either.t
+
+and type_param_diff =
+  | Added_tp of Types.type_expr
+  | Removed_tp of Types.type_expr
 
 type class_ = {
   cname : string;

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -13,7 +13,7 @@ type type_ = {
 }
 
 and type_modification = {
-  type_kind : type_kind option;
+  type_kind : (Types.type_decl_kind, type_kind) Either.t;
   type_privacy : (Asttypes.private_flag, type_privacy) Either.t;
   type_manifest :
     ( Types.type_expr option,
@@ -21,9 +21,7 @@ and type_modification = {
     Either.t;
 }
 
-and type_privacy =
-  | Added_p
-  | Removed_p
+and type_privacy = Added_p | Removed_p
 
 and type_kind =
   | Record_tk of record_field list

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -14,9 +14,12 @@ type type_ = {
 
 and type_modification =
   | Compound_tm of {
-      type_kind_mismatch : type_kind_mismatch option;
-      type_privacy_mismatch :
+    type_kind_mismatch : type_kind_mismatch option;
+    type_privacy_mismatch :
         (Asttypes.private_flag, type_privacy_diff) Either.t;
+   type_manifest_mismatch :
+    ( Types.type_expr option,
+      (Types.type_expr, Types.type_expr atomic_modification) t ) Either.t;
     }
   | Atomic_tm of Types.type_declaration atomic_modification
 

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -13,8 +13,16 @@ type type_ = {
 }
 
 and type_modification =
-  | Compound_tm of { type_kind_mismatch : type_kind_mismatch option }
+  | Compound_tm of {
+      type_kind_mismatch : type_kind_mismatch option;
+      type_privacy_mismatch :
+        (Asttypes.private_flag, type_privacy_diff) Either.t;
+    }
   | Atomic_tm of Types.type_declaration atomic_modification
+
+and type_privacy_diff =
+  | Added_p of Asttypes.private_flag
+  | Removed_p of Asttypes.private_flag
 
 and type_kind_mismatch =
   | Record_mismatch of record_field list

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -158,7 +158,67 @@ and order_type_diffs type_header_diff type_kind_diff =
 
 and process_type_header_diff name type_privacy type_manifest type_kind =
   match (type_privacy, type_manifest, type_kind) with
-  | Either.Left private_flag, Either.Left te_opt, Either.Right _ ->
+  | Either.Left private_flag, Either.Left te_opt, Either.Right (Record_tk _)
+  | Either.Left private_flag, Either.Left te_opt, Either.Right (Variant_tk _)
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk
+          {
+            reference = Types.Type_record (_, _);
+            current = Types.Type_record (_, _);
+          }) )
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk
+          {
+            reference = Types.Type_record (_, _);
+            current = Types.Type_variant (_, _);
+          }) )
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk
+          { reference = Types.Type_record (_, _); current = Types.Type_open }) )
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk
+          {
+            reference = Types.Type_variant (_, _);
+            current = Types.Type_record (_, _);
+          }) )
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk
+          {
+            reference = Types.Type_variant (_, _);
+            current = Types.Type_variant (_, _);
+          }) )
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk
+          { reference = Types.Type_variant (_, _); current = Types.Type_open })
+    )
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk
+          { reference = Types.Type_open; current = Types.Type_record (_, _) }) )
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk
+          { reference = Types.Type_open; current = Types.Type_variant (_, _) })
+    )
+  | ( Either.Left private_flag,
+      Either.Left te_opt,
+      Either.Right
+        (Atomic_tk { reference = Types.Type_open; current = Types.Type_open }) )
+    ->
       `Same [ Same (type_header_to_line name private_flag te_opt false) ]
   | type_privacy_diff, type_manifest_diff, type_kind_diff ->
       let ref_private_flag, cur_private_flag =

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -104,7 +104,7 @@ let ctd_to_lines name cd =
   CCString.lines class_str
 
 let indent n h =
-  let indentation = String.init n (fun _ -> ' ') in
+  let indentation = String.make n ' ' in
   match h with
   | Same s -> Same (indentation ^ s)
   | Change { orig; new_ } ->
@@ -340,14 +340,14 @@ and type_kind_to_lines type_kind : string list option =
   | Types.Type_open -> Some [ indent_s 1 ".." ]
 
 and indent_s n s =
-  let indentation = String.init n (fun _ -> ' ') in
+  let indentation = String.make n ' ' in
   indentation ^ s
 
 and process_modified_record_type_diff ~indent_amount diff =
   let changes = process_modified_labels diff in
-  [ indent indent_amount (Same "{") ]
-  @ [ indent (indent_amount + 2) (Same "...") ]
-  @ List.map (fun c -> indent (indent_amount + 2) c) changes
+  indent indent_amount (Same "{")
+  :: indent (indent_amount + 2) (Same "...")
+  :: List.map (fun c -> indent (indent_amount + 2) c) changes
   @ [ indent indent_amount (Same "}") ]
 
 and process_modified_labels (lbls_diffs : Diff.record_field list) =

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -158,12 +158,7 @@ and order_type_diffs type_header_diff type_kind_diff =
 
 and process_type_header_diff name type_privacy type_manifest type_kind =
   match (type_privacy, type_manifest, type_kind) with
-  | ( Either.Left private_flag,
-      Either.Left te_opt,
-      Either.Right (Diff.Record_tk _) )
-  | ( Either.Left private_flag,
-      Either.Left te_opt,
-      Either.Right (Diff.Variant_tk _) ) ->
+  | Either.Left private_flag, Either.Left te_opt, Either.Right _ ->
       `Same [ Same (type_header_to_line name private_flag te_opt false) ]
   | type_privacy_diff, type_manifest_diff, type_kind_diff ->
       let ref_private_flag, cur_private_flag =

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -133,16 +133,24 @@ let process_atomic_diff (diff : (_, _ Diff.atomic_modification) Diff.t) name
 
 let rec process_type_diff (type_diff : Diff.type_) =
   match type_diff.tdiff with
-  | Diff.Modified { type_kind_mismatch = Some (Record_mismatch change_lst) } ->
+  | Diff.Modified
+      (Compound_tm { type_kind_mismatch = Some (Record_mismatch change_lst) })
+    ->
       Same ("type " ^ type_diff.tname ^ " = {")
       :: process_modified_record_type_diff ~indent_n:2 change_lst
       @ [ Same "}" ]
-  | Diff.Modified { type_kind_mismatch = Some (Variant_mismatch change_lst) } ->
+  | Diff.Modified
+      (Compound_tm { type_kind_mismatch = Some (Variant_mismatch change_lst) })
+    ->
       Same ("type " ^ type_diff.tname ^ " =")
       :: process_modified_variant_type_diff change_lst
   | Diff.Modified
-      { type_kind_mismatch = Some (Atomic_mismatch { reference; current }) } ->
+      (Compound_tm
+        { type_kind_mismatch = Some (Atomic_mismatch { reference; current }) })
+    ->
       process_atomic_type_kind_diff type_diff.tname reference current
+  | Diff.Modified (Atomic_tm mods) ->
+      process_atomic_diff (Diff.Modified mods) type_diff.tname td_to_lines
   | Diff.Added td ->
       process_atomic_diff (Diff.Added td) type_diff.tname td_to_lines
   | Diff.Removed td ->

--- a/lib/text_diff.ml
+++ b/lib/text_diff.ml
@@ -119,19 +119,20 @@ let process_atomic_diff (diff : (_, _ Diff.atomic_modification) Diff.t) name
 
 let rec process_type_diff (type_diff : Diff.type_) =
   match type_diff.tdiff with
-  | Diff.Modified (Record_diff change_lst) ->
+  | Diff.Modified (_, Some (Record_mismatch change_lst), _) ->
       Same ("type " ^ type_diff.tname ^ " = {")
       :: process_modified_record_type_diff ~indent_n:2 change_lst
       @ [ Same "}" ]
-  | Diff.Modified (Variant_diff change_lst) ->
+  | Diff.Modified (_, Some (Variant_mismatch change_lst), _) ->
       Same ("type " ^ type_diff.tname ^ " =")
       :: process_modified_variant_type_diff change_lst
-  | Diff.Modified (Atomic mods) ->
+  | Diff.Modified (_, Some (Atomic_mismatch mods), _) ->
       process_atomic_diff (Diff.Modified mods) type_diff.tname td_to_lines
   | Diff.Added td ->
       process_atomic_diff (Diff.Added td) type_diff.tname td_to_lines
   | Diff.Removed td ->
       process_atomic_diff (Diff.Removed td) type_diff.tname td_to_lines
+  | _ -> assert false
 
 and process_modified_record_type_diff ~indent_n diff =
   let changes = process_modified_labels diff in

--- a/tests/api-diff/modified_variant_type_tests.t
+++ b/tests/api-diff/modified_variant_type_tests.t
@@ -27,7 +27,7 @@ Run the api-watcher on the two cmi files
    type rank =
     ...
   + | Jack
-
+  
   [1]
 
 ### Removing a constructor from a variant type:
@@ -47,7 +47,7 @@ Run the api-watcher on the two cmi files
    type rank =
     ...
   - | Number of int
-
+  
   [1]
 
 ### Modifying a constructor's arguments in a variant type:
@@ -68,7 +68,7 @@ Run the api-watcher on the two cmi files
     ...
   - | Number of int
   + | Number of float
-
+  
   [1]
 
 Tests for modifying constructor's record argument
@@ -89,8 +89,8 @@ We generate the .cmi file
   $ cat > add_field.mli << EOF
   > type point = float * float
   > type shape =
-  >  | Circle of {center : point; raduis: int; color:int}
-  >  | Rectangle of {lower_left: point; upper_right: point; color:int}
+  >  | Circle of { center : point; raduis: int; color:int }
+  >  | Rectangle of { lower_left: point; upper_right: point; color:int }
   > EOF
 
 We generate the .cmi file
@@ -121,8 +121,8 @@ Run the api-watcher on the two cmi files
   $ cat > remove_field.mli << EOF
   > type point = float * float
   > type shape =
-  >  | Circle of {center : point;}
-  >  | Rectangle of {lower_left: point; upper_right: point;}
+  >  | Circle of { center : point; }
+  >  | Rectangle of { lower_left: point; upper_right: point; }
   > EOF
 
 We generate the .cmi file
@@ -148,8 +148,8 @@ Run the api-watcher on the two cmi files
   $ cat > modify_field.mli << EOF
   > type point = float * float
   > type shape =
-  >  | Circle of {center : point; raduis: float;}
-  >  | Rectangle of {lower_left: point; upper_right: point;}
+  >  | Circle of { center : point; raduis: float; }
+  >  | Rectangle of { lower_left: point; upper_right: point; }
   > EOF
 
 We generate the .cmi file

--- a/tests/api-diff/modified_variant_type_tests.t
+++ b/tests/api-diff/modified_variant_type_tests.t
@@ -24,7 +24,7 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_constructor.cmi
   diff module Add_constructor:
-   type rank =
+   type rank = 
     ...
   + | Jack
   

--- a/tests/api-diff/modified_variant_type_tests.t
+++ b/tests/api-diff/modified_variant_type_tests.t
@@ -25,8 +25,8 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi add_constructor.cmi
   diff module Add_constructor:
    type rank =
-     ...
-  +  | Jack
+    ...
+  + | Jack
 
   [1]
 
@@ -45,8 +45,8 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi remove_constructor.cmi
   diff module Remove_constructor:
    type rank =
-     ...
-  -  | Number of int
+    ...
+  - | Number of int
 
   [1]
 
@@ -65,9 +65,9 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi modify_constructor_type.cmi
   diff module Modify_constructor_type:
    type rank =
-     ...
-  -  | Number of int
-  +  | Number of float
+    ...
+  - | Number of int
+  + | Number of float
 
   [1]
 
@@ -76,8 +76,8 @@ Tests for modifying constructor's record argument
   $ cat > shapes.mli << EOF
   > type point = float * float
   > type shape =
-  >  | Circle of {center : point; raduis: int}
-  >  | Rectangle of {lower_left: point; upper_right: point}
+  >  | Circle of { center : point; raduis: int }
+  >  | Rectangle of { lower_left: point; upper_right: point }
   > EOF
 
 We generate the .cmi file
@@ -102,17 +102,17 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes.cmi add_field.cmi
   diff module Add_field:
    type shape =
-     ...
-     | Circle of
-       {
-          ...
-  +       color : int;
-        }
-     | Rectangle of
-        {
+    ...
+    | Circle of
+      {
         ...
   +     color : int;
-        }
+      }
+    | Rectangle of
+      {
+        ...
+  +     color : int;
+      }
   
   [1]
 
@@ -202,11 +202,11 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi add_component.cmi
   diff module Add_component:
    type shape =
-       ...
-  -    | Circle of point * int
-  +    | Circle of point * int * int
-  -    | Rectangle of point * point
-  +    | Rectangle of point * point * int
+    ...
+  - | Circle of point * int
+  + | Circle of point * int * int
+  - | Rectangle of point * point
+  + | Rectangle of point * point * int
   
   [1]
 
@@ -228,9 +228,9 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi remove_component.cmi
   diff module Remove_component:
    type shape =
-       ...
-  -    | Circle of point * int
-  +    | Circle of point
+    ...
+  - | Circle of point * int
+  + | Circle of point
   
   [1]
 
@@ -252,8 +252,8 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi modify_component.cmi
   diff module Modify_component:
    type shape =
-       ...
-  -    | Circle of point * int
-  +    | Circle of point * float
+    ...
+  - | Circle of point * int
+  + | Circle of point * float
   
   [1]

--- a/tests/api-diff/modified_variant_type_tests.t
+++ b/tests/api-diff/modified_variant_type_tests.t
@@ -18,16 +18,16 @@ We generate the .cmi file
 
 We generate the .cmi file
 
-  $ ocamlc add_constructor.mli 
+  $ ocamlc add_constructor.mli
 
 Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_constructor.cmi
   diff module Add_constructor:
-   type rank = 
-    ...
-  + | Jack
-  
+   type rank =
+     ...
+  +  | Jack
+
   [1]
 
 ### Removing a constructor from a variant type:
@@ -45,12 +45,12 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi remove_constructor.cmi
   diff module Remove_constructor:
    type rank =
-    ...
-  - | Number of int
-  
+     ...
+  -  | Number of int
+
   [1]
 
-### Modifying a constructor's arguments in a variant type: 
+### Modifying a constructor's arguments in a variant type:
 
   $ cat > modify_constructor_type.mli << EOF
   > type rank = Ace | King | Queen | Number of float
@@ -65,17 +65,17 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi modify_constructor_type.cmi
   diff module Modify_constructor_type:
    type rank =
-    ...
-  - | Number of int
-  + | Number of float
-  
+     ...
+  -  | Number of int
+  +  | Number of float
+
   [1]
 
 Tests for modifying constructor's record argument
 
   $ cat > shapes.mli << EOF
   > type point = float * float
-  > type shape = 
+  > type shape =
   >  | Circle of {center : point; raduis: int}
   >  | Rectangle of {lower_left: point; upper_right: point}
   > EOF
@@ -88,31 +88,31 @@ We generate the .cmi file
 
   $ cat > add_field.mli << EOF
   > type point = float * float
-  > type shape = 
+  > type shape =
   >  | Circle of {center : point; raduis: int; color:int}
   >  | Rectangle of {lower_left: point; upper_right: point; color:int}
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc add_field.mli 
+  $ ocamlc add_field.mli
 
 Run the api-watcher on the two cmi files
 
   $ api-diff shapes.cmi add_field.cmi
   diff module Add_field:
    type shape =
-       ...
-       | Circle of 
-        {
-         ...
-  +      color : int;
+     ...
+     | Circle of
+       {
+          ...
+  +       color : int;
         }
-    | Rectangle of 
-      {
+     | Rectangle of
+        {
         ...
   +     color : int;
-      }
+        }
   
   [1]
 
@@ -120,14 +120,14 @@ Run the api-watcher on the two cmi files
 
   $ cat > remove_field.mli << EOF
   > type point = float * float
-  > type shape = 
+  > type shape =
   >  | Circle of {center : point;}
   >  | Rectangle of {lower_left: point; upper_right: point;}
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc remove_field.mli 
+  $ ocamlc remove_field.mli
 
 Run the api-watcher on the two cmi files
 
@@ -135,7 +135,7 @@ Run the api-watcher on the two cmi files
   diff module Remove_field:
    type shape =
     ...
-    | Circle of 
+    | Circle of
       {
         ...
   -     raduis : int;
@@ -147,14 +147,14 @@ Run the api-watcher on the two cmi files
 
   $ cat > modify_field.mli << EOF
   > type point = float * float
-  > type shape = 
+  > type shape =
   >  | Circle of {center : point; raduis: float;}
   >  | Rectangle of {lower_left: point; upper_right: point;}
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc modify_field.mli 
+  $ ocamlc modify_field.mli
 
 Run the api-watcher on the two cmi files
 
@@ -162,7 +162,7 @@ Run the api-watcher on the two cmi files
   diff module Modify_field:
    type shape =
     ...
-    | Circle of 
+    | Circle of
       {
         ...
   -     raduis : int;
@@ -175,7 +175,7 @@ Tests for modifying constructor's tuple argument
 
   $ cat > shapes2.mli << EOF
   > type point = float * float
-  > type shape = 
+  > type shape =
   >  | Circle of point * int
   >  | Rectangle of point * point
   > EOF
@@ -188,14 +188,14 @@ We generate the .cmi file
 
   $ cat > add_component.mli << EOF
   > type point = float * float
-  > type shape = 
+  > type shape =
   >  | Circle of point * int * int
   >  | Rectangle of point * point * int
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc add_component.mli 
+  $ ocamlc add_component.mli
 
 Run the api-watcher on the two cmi files
 
@@ -214,14 +214,14 @@ Run the api-watcher on the two cmi files
 
   $ cat > remove_component.mli << EOF
   > type point = float * float
-  > type shape = 
+  > type shape =
   >  | Circle of point
   >  | Rectangle of point * point
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc remove_component.mli 
+  $ ocamlc remove_component.mli
 
 Run the api-watcher on the two cmi files
 
@@ -238,14 +238,14 @@ Run the api-watcher on the two cmi files
 
   $ cat > modify_component.mli << EOF
   > type point = float * float
-  > type shape = 
+  > type shape =
   >  | Circle of point * float
   >  | Rectangle of point * point
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc modify_component.mli 
+  $ ocamlc modify_component.mli
 
 Run the api-watcher on the two cmi files
 

--- a/tests/api-diff/modified_variant_type_tests.t
+++ b/tests/api-diff/modified_variant_type_tests.t
@@ -102,15 +102,17 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes.cmi add_field.cmi
   diff module Add_field:
    type shape =
-    ...
-    | Circle of {
        ...
-  +    color : int;
-    }
-    | Rectangle of {
-       ...
-  +    color : int;
-    }
+       | Circle of 
+        {
+         ...
+  +      color : int;
+        }
+    | Rectangle of 
+      {
+        ...
+  +     color : int;
+      }
   
   [1]
 
@@ -133,10 +135,11 @@ Run the api-watcher on the two cmi files
   diff module Remove_field:
    type shape =
     ...
-    | Circle of {
-       ...
-  -    raduis : int;
-    }
+    | Circle of 
+      {
+        ...
+  -     raduis : int;
+      }
   
   [1]
 
@@ -159,11 +162,12 @@ Run the api-watcher on the two cmi files
   diff module Modify_field:
    type shape =
     ...
-    | Circle of {
-       ...
-  -    raduis : int;
-  +    raduis : float;
-    }
+    | Circle of 
+      {
+        ...
+  -     raduis : int;
+  +     raduis : float;
+      }
   
   [1]
 
@@ -198,11 +202,11 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi add_component.cmi
   diff module Add_component:
    type shape =
-    ...
-  - | Circle of point * int
-  + | Circle of point * int * int
-  - | Rectangle of point * point
-  + | Rectangle of point * point * int
+       ...
+  -    | Circle of point * int
+  +    | Circle of point * int * int
+  -    | Rectangle of point * point
+  +    | Rectangle of point * point * int
   
   [1]
 
@@ -224,9 +228,9 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi remove_component.cmi
   diff module Remove_component:
    type shape =
-    ...
-  - | Circle of point * int
-  + | Circle of point
+       ...
+  -    | Circle of point * int
+  +    | Circle of point
   
   [1]
 
@@ -248,8 +252,8 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi modify_component.cmi
   diff module Modify_component:
    type shape =
-    ...
-  - | Circle of point * int
-  + | Circle of point * float
+       ...
+  -    | Circle of point * int
+  +    | Circle of point * float
   
   [1]

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -1,7 +1,7 @@
 Here we generate a `.mli` file with a record type:
 
   $ cat > ref.mli << EOF
-  > type student = {first_name: string; last_name: string; id: int option}
+  > type student = { first_name: string; last_name: string; id: int option }
   > EOF
 
 We generate the .cmi file
@@ -13,7 +13,7 @@ We generate the .cmi file
 ### Adding a field to a record type:
 
   $ cat > add_field.mli << EOF
-  > type student = {first_name: string; last_name: string; id: int option; level: int}
+  > type student = { first_name: string; last_name: string; id: int option; level: int }
   > EOF
 
 We generate the .cmi file
@@ -35,7 +35,7 @@ Run the api-watcher on the two cmi files
 ### Removing a field from a record type:
 
   $ cat > remove_field.mli << EOF
-  > type student = {first_name: string; last_name: string}
+  > type student = { first_name: string; last_name: string }
   > EOF
 
 We generate the .cmi file
@@ -57,7 +57,7 @@ Run the api-watcher on the two cmi files
 ### Modifying a field's type in a record type:
 
   $ cat > modify_field_type.mli << EOF
-  > type student = {first_name: string; last_name: string; id: int}
+  > type student = { first_name: string; last_name: string; id: int }
   > EOF
 
 We generate the .cmi file
@@ -81,7 +81,7 @@ Run api-watcher on the two cmi files
 
   $ cat > alias_field_type.mli << EOF
   > type y = int option
-  > type student = {first_name: string; last_name: string; id: y}
+  > type student = { first_name: string; last_name: string; id: y }
   > EOF
 
 We generate the .cmi file

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -69,11 +69,11 @@ Run api-watcher on the two cmi files
   $ api-diff ref.cmi modify_field_type.cmi
   diff module Modify_field_type:
    type student = 
-       {
-         ...
-  -      id : int option;
-  +      id : int;
-       }
+    {
+      ...
+  -   id : int option;
+  +   id : int;
+    }
   
   [1]
 

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -18,40 +18,40 @@ We generate the .cmi file
 
 We generate the .cmi file
 
-  $ ocamlc add_field.mli 
+  $ ocamlc add_field.mli
 
 Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_field.cmi
   diff module Add_field:
-   type student = 
-       {
-         ...
-  +      level : int;
-       }
-  
+   type student =
+    {
+      ...
+  +   level : int;
+    }
+
   [1]
 
 ### Removing a field from a record type:
 
-  $ cat > remove_field.mli << EOF 
+  $ cat > remove_field.mli << EOF
   > type student = {first_name: string; last_name: string}
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc remove_field.mli 
+  $ ocamlc remove_field.mli
 
 Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_field.cmi
   diff module Remove_field:
-   type student = 
-       {
-         ...
-  -      id : int option;
-       }
-  
+   type student =
+    {
+      ...
+  -   id : int option;
+    }
+
   [1]
 
 ### Modifying a field's type in a record type:
@@ -68,13 +68,13 @@ Run api-watcher on the two cmi files
 
   $ api-diff ref.cmi modify_field_type.cmi
   diff module Modify_field_type:
-   type student = 
+   type student =
     {
       ...
   -   id : int option;
   +   id : int;
     }
-  
+
   [1]
 
 ### Modifying a field's type in a record type to a same alias type:

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -29,7 +29,7 @@ Run the api-watcher on the two cmi files
       ...
   +   level : int;
     }
-
+  
   [1]
 
 ### Removing a field from a record type:
@@ -51,7 +51,7 @@ Run the api-watcher on the two cmi files
       ...
   -   id : int option;
     }
-
+  
   [1]
 
 ### Modifying a field's type in a record type:
@@ -74,7 +74,7 @@ Run api-watcher on the two cmi files
   -   id : int option;
   +   id : int;
     }
-
+  
   [1]
 
 ### Modifying a field's type in a record type to a same alias type:

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -24,10 +24,11 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_field.cmi
   diff module Add_field:
-   type student = {
-     ...
-  +  level : int;
-   }
+   type student = 
+       {
+         ...
+  +      level : int;
+       }
   
   [1]
 
@@ -45,10 +46,11 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_field.cmi
   diff module Remove_field:
-   type student = {
-     ...
-  -  id : int option;
-   }
+   type student = 
+       {
+         ...
+  -      id : int option;
+       }
   
   [1]
 
@@ -66,11 +68,12 @@ Run api-watcher on the two cmi files
 
   $ api-diff ref.cmi modify_field_type.cmi
   diff module Modify_field_type:
-   type student = {
-     ...
-  -  id : int option;
-  +  id : int;
-   }
+   type student = 
+       {
+         ...
+  -      id : int option;
+  +      id : int;
+       }
   
   [1]
 

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -44,8 +44,9 @@ Run the api-watcher on record and varient type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
   diff module Ref_variant_kind:
-  -type t = { a : int; ; b : float; }
-  +type t = A of int | B of string
+  type t = 
+  -   { a : int; ; b : float; }
+  +   A of int | B of string
   
   [1]
 
@@ -53,8 +54,9 @@ Run the api-watcher on record and abstract type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
   diff module Ref_abstract_kind:
-  -type t = { a : int; ; b : float; }
-  +type t
+  type t =
+  -   { a : int; ; b : float; }
+  +   <abstract>
   
   [1]
 
@@ -62,8 +64,9 @@ Run the api-watcher on record and open type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_open_kind.cmi
   diff module Ref_open_kind:
-  -type t = { a : int; ; b : float; }
-  +type t = ..
+  type t =
+  -   { a : int; ; b : float; }
+  +   <open>
   
   [1]
 

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -44,9 +44,12 @@ Run the api-watcher on record and varient type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
   diff module Ref_variant_kind:
-  type t = 
-  -   { a : int; ; b : float; }
-  +   A of int | B of string
+  -type t = 
+  - { a : int
+  -   b : float; }
+  +type t = 
+  + | A of int 
+  + | B of string
   
   [1]
 
@@ -54,9 +57,10 @@ Run the api-watcher on record and abstract type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
   diff module Ref_abstract_kind:
-  type t =
-  -   { a : int; ; b : float; }
-  +   <abstract>
+  -type t =
+  - { a : int;
+  -   b : float; }
+  +type t
   
   [1]
 
@@ -64,9 +68,10 @@ Run the api-watcher on record and open type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_open_kind.cmi
   diff module Ref_open_kind:
-  type t =
-  -   { a : int; ; b : float; }
-  +   <open>
+  -type t =
+  - { a : int;
+      b : float; }
+  +type t = ..
   
   [1]
 

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -55,8 +55,9 @@ Run the api-watcher on record and abstract type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
   diff module Ref_abstract_kind:
-   type t =
+  -type t =
   - { a : int; b : float; }
+  +type t
   
   [1]
 

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -1,0 +1,68 @@
+Here we generate `.mli` files for testing the changes in the type kinds
+
+# A .mli file with a record type
+
+  $ cat > ref_record_kind.mli << EOF
+  > type t = { a: int; b: float }
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc ref_record_kind.mli
+
+### A file with a variant type:
+
+  $ cat > cur_variant_kind.mli << EOF
+  > type t = A of int | B of string
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc cur_variant_kind.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref_record_kind.cmi cur_variant_kind.cmi
+  diff module Cur_variant_kind:
+  -type t = { a : int; ; b : float; }
+  +type t = A of int | B of string
+
+  [1]
+
+### A file with an abstract type:
+
+  $ cat > cur_abstract_kind.mli << EOF
+  > type t
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc cur_abstract_kind.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref_record_kind.cmi cur_abstract_kind.cmi
+  diff module Cur_abstract_kind:
+  -type t = { a : int; b : float }
+  +type t
+
+  [1]
+
+### A file with an open type:
+
+  $ cat > cur_open_kind.mli << EOF
+  > type t = ..
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc cur_open_kind.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref_record_kind.cmi cur_open_kind.cmi
+  diff module Cur_open_kind:
+  -type t = { a : int; b : float }
+  +type t = ..
+
+  [1]

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -45,13 +45,13 @@ Run the api-watcher on record and varient type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
   diff module Ref_variant_kind:
   -type t =
-  -  {
-  -    a : int;
-  -    b : float;
-  -  }
+  - {
+  -   a : int;
+  -   b : float;
+  - }
   +type t =
-  +  | A of int
-  +  | B of string
+  + | A of int
+  + | B of string
   
   [1]
 
@@ -60,10 +60,10 @@ Run the api-watcher on record and abstract type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
   diff module Ref_abstract_kind:
   -type t =
-  -  {
-  -    a : int;
-  -    b : float;
-  -  }
+  - {
+  -   a : int;
+  -   b : float;
+  - }
   +type t
   
   [1]
@@ -73,11 +73,12 @@ Run the api-watcher on record and open type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_open_kind.cmi
   diff module Ref_open_kind:
   -type t =
-  -  {
-  -    a : int;
-  -    b : float;
-  -  }
-  +type t = ..
+  - {
+  -   a : int;
+  -   b : float;
+  - }
+  +type t =
+  + ..
   
   [1]
 

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -44,12 +44,14 @@ Run the api-watcher on record and varient type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
   diff module Ref_variant_kind:
-  -type t = 
-  - { a : int
-  -   b : float; }
-  +type t = 
-  + | A of int 
-  + | B of string
+  -type t =
+  -  {
+  -    a : int;
+  -    b : float;
+  -  }
+  +type t =
+  +  | A of int
+  +  | B of string
   
   [1]
 
@@ -58,8 +60,10 @@ Run the api-watcher on record and abstract type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
   diff module Ref_abstract_kind:
   -type t =
-  - { a : int;
-  -   b : float; }
+  -  {
+  -    a : int;
+  -    b : float;
+  -  }
   +type t
   
   [1]
@@ -69,8 +73,10 @@ Run the api-watcher on record and open type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_open_kind.cmi
   diff module Ref_open_kind:
   -type t =
-  - { a : int;
-      b : float; }
+  -  {
+  -    a : int;
+  -    b : float;
+  -  }
   +type t = ..
   
   [1]

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -1,6 +1,6 @@
-Here we generate `.mli` files for testing the changes in the type kinds
+Here we generate files for testing the changes in the type kinds
 
-# A .mli file with a record type
+# A `.mli` file with a record type
 
   $ cat > ref_record_kind.mli << EOF
   > type t = { a: int; b: float }
@@ -10,59 +10,67 @@ We generate the .cmi file
 
   $ ocamlc ref_record_kind.mli
 
-### A file with a variant type:
+### A `.mli` file with a variant type:
 
-  $ cat > cur_variant_kind.mli << EOF
+  $ cat > ref_variant_kind.mli << EOF
   > type t = A of int | B of string
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc cur_variant_kind.mli
+  $ ocamlc ref_variant_kind.mli
 
-Run the api-watcher on the two cmi files
+### A `.mli` file with an abstract type:
 
-  $ api-diff ref_record_kind.cmi cur_variant_kind.cmi
-  diff module Cur_variant_kind:
-  -type t = { a : int; ; b : float; }
-  +type t = A of int | B of string
-
-  [1]
-
-### A file with an abstract type:
-
-  $ cat > cur_abstract_kind.mli << EOF
+  $ cat > ref_abstract_kind.mli << EOF
   > type t
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc cur_abstract_kind.mli
+  $ ocamlc ref_abstract_kind.mli
 
-Run the api-watcher on the two cmi files
+### A `.mli` file with an open type:
 
-  $ api-diff ref_record_kind.cmi cur_abstract_kind.cmi
-  diff module Cur_abstract_kind:
-  -type t = { a : int; b : float }
-  +type t
-
-  [1]
-
-### A file with an open type:
-
-  $ cat > cur_open_kind.mli << EOF
+  $ cat > ref_open_kind.mli << EOF
   > type t = ..
   > EOF
 
 We generate the .cmi file
 
-  $ ocamlc cur_open_kind.mli
+  $ ocamlc ref_open_kind.mli
 
-Run the api-watcher on the two cmi files
+Run the api-watcher on record and varient type kinds cmi files
 
-  $ api-diff ref_record_kind.cmi cur_open_kind.cmi
-  diff module Cur_open_kind:
-  -type t = { a : int; b : float }
-  +type t = ..
-
+  $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
+  diff module Ref_variant_kind:
+  -type t = { a : int; ; b : float; }
+  +type t = A of int | B of string
+  
   [1]
+
+Run the api-watcher on record and abstract type kinds cmi files
+
+  $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
+  diff module Ref_abstract_kind:
+  -type t = { a : int; ; b : float; }
+  +type t
+  
+  [1]
+
+Run the api-watcher on record and open type kinds cmi files
+
+  $ api-diff ref_record_kind.cmi ref_open_kind.cmi
+  diff module Ref_open_kind:
+  -type t = { a : int; ; b : float; }
+  +type t = ..
+  
+  [1]
+
+Run the api-watcher on two abstract type kinds cmi files
+
+  $ api-diff ref_abstract_kind.cmi ref_abstract_kind.cmi
+
+Run the api-watcher on two open type kinds cmi files
+
+  $ api-diff ref_open_kind.cmi ref_open_kind.cmi

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -45,10 +45,7 @@ Run the api-watcher on record and varient type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
   diff module Ref_variant_kind:
   -type t =
-  - {
-  -   a : int;
-  -   b : float;
-  - }
+  - { a : int; b : float; }
   +type t =
   + | A of int
   + | B of string
@@ -60,10 +57,7 @@ Run the api-watcher on record and abstract type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
   diff module Ref_abstract_kind:
   -type t =
-  - {
-  -   a : int;
-  -   b : float;
-  - }
+  - { a : int; b : float; }
   +type t
   
   [1]
@@ -73,10 +67,7 @@ Run the api-watcher on record and open type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_open_kind.cmi
   diff module Ref_open_kind:
   -type t =
-  - {
-  -   a : int;
-  -   b : float;
-  - }
+  - { a : int; b : float; }
   +type t =
   + ..
   

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -44,9 +44,8 @@ Run the api-watcher on record and varient type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
   diff module Ref_variant_kind:
-  -type t =
+   type t =
   - { a : int; b : float; }
-  +type t =
   + | A of int
   + | B of string
   
@@ -56,9 +55,8 @@ Run the api-watcher on record and abstract type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
   diff module Ref_abstract_kind:
-  -type t =
+   type t =
   - { a : int; b : float; }
-  +type t
   
   [1]
 
@@ -66,9 +64,8 @@ Run the api-watcher on record and open type kinds cmi files
 
   $ api-diff ref_record_kind.cmi ref_open_kind.cmi
   diff module Ref_open_kind:
-  -type t =
+   type t =
   - { a : int; b : float; }
-  +type t =
   + ..
   
   [1]

--- a/tests/api-diff/type_manifest_tests.t
+++ b/tests/api-diff/type_manifest_tests.t
@@ -1,0 +1,25 @@
+Here we generate a `.mli` file to test the changes in the type manifest
+
+  $ cat > ref.mli << EOF
+  > type t
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc ref.mli
+
+### Adding a type manifest
+
+  $ cat > add_manifest.mli << EOF
+  > type t = int list
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc add_manifest.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi add_manifest.cmi
+  diff module Add_manifest:
+  type t = +int list

--- a/tests/api-diff/type_manifest_tests.t
+++ b/tests/api-diff/type_manifest_tests.t
@@ -24,6 +24,26 @@ Run the api-watcher on the two cmi files
   diff module Add_manifest:
   -type t
   +type t = int list
+   
+  
+  [1]
 
+### Adding a type manifest and private type abberivation
+
+  $ cat > add_manifest_private.mli << EOF
+  > type t = private int list
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc add_manifest_private.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi add_manifest_private.cmi
+  diff module Add_manifest_private:
+  -type t
+  +type t = private int list
+   
   
   [1]

--- a/tests/api-diff/type_manifest_tests.t
+++ b/tests/api-diff/type_manifest_tests.t
@@ -22,4 +22,7 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_manifest.cmi
   diff module Add_manifest:
-  type t = +int list
+  type t = 
+  +   int list
+
+  [1]

--- a/tests/api-diff/type_manifest_tests.t
+++ b/tests/api-diff/type_manifest_tests.t
@@ -22,7 +22,8 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_manifest.cmi
   diff module Add_manifest:
-   -type t
-   +type t = int list
-   
+  -type t
+  +type t = int list
+
+  
   [1]

--- a/tests/api-diff/type_manifest_tests.t
+++ b/tests/api-diff/type_manifest_tests.t
@@ -24,7 +24,6 @@ Run the api-watcher on the two cmi files
   diff module Add_manifest:
   -type t
   +type t = int list
-   
   
   [1]
 
@@ -44,6 +43,5 @@ Run the api-watcher on the two cmi files
   diff module Add_manifest_private:
   -type t
   +type t = private int list
-   
   
   [1]

--- a/tests/api-diff/type_manifest_tests.t
+++ b/tests/api-diff/type_manifest_tests.t
@@ -22,7 +22,7 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi add_manifest.cmi
   diff module Add_manifest:
-  type t = 
-  +   int list
-
+   -type t
+   +type t = int list
+   
   [1]

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -22,9 +22,13 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_private.cmi
   diff module Remove_private:
-   type t = 
-   -   private
-  
+  -type t = private 
+    { a : int
+    ; b : float }
+  +type t = 
+    { a : int
+    ; b : float } 
+
   [1]
 
 # Removing a private type abbreviation from a type declaration and modifying record fields
@@ -41,13 +45,14 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_private_modify_record.cmi
   diff module Remove_private_modify_record:
-   type t =
-   -   private 
-       {
-         ...
-  -      a : int;
-  +      a : float;
-  -      b : float;
-       }
-  
+  -type t = private
+  +type t =
+    {
+      ...
+  -   a : int;
+  +   a : float;
+  -   b : float;
+    }
+ 
   [1]
+

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -1,0 +1,25 @@
+Here we generate a `.mli` file with a private type abbreviation
+
+  $ cat > ref.mli << EOF
+  > type t = private int
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc ref.mli
+
+# Removing a private type abbreviation from a type declaration
+
+  $ cat > remove_private.mli << EOF
+  > type t = int
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc remove_private.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi remove_private.cmi
+  diff module Remove_private:
+  type t = -private int

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -24,10 +24,7 @@ Run the api-watcher on the two cmi files
   diff module Remove_private:
   -type t = private
   +type t =
-    {
-      a : int;
-      b : float;
-    }
+    { a : int; b : float; }
   
   [1]
 

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -22,13 +22,13 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_private.cmi
   diff module Remove_private:
-   -type t = private
-   +type t =
-     { 
-       a : int; 
-       b : float 
-     } 
-
+  -type t = private
+  +type t =
+    {
+      a : int;
+      b : float;
+    }
+  
   [1]
 
 # Removing a private type abbreviation from a type declaration and modifying record fields

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -22,12 +22,12 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_private.cmi
   diff module Remove_private:
-  -type t = private 
-    { a : int
-    ; b : float }
-  +type t = 
-    { a : int
-    ; b : float } 
+   -type t = private
+   +type t =
+     { 
+       a : int; 
+       b : float 
+     } 
 
   [1]
 
@@ -53,6 +53,6 @@ Run the api-watcher on the two cmi files
   +   a : float;
   -   b : float;
     }
- 
+  
   [1]
 

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -1,7 +1,7 @@
 Here we generate a `.mli` file with a private type abbreviation
 
   $ cat > ref.mli << EOF
-  > type t = private int
+  > type t = private { a : int; b : float }
   > EOF
 
 We generate the .cmi file
@@ -11,7 +11,7 @@ We generate the .cmi file
 # Removing a private type abbreviation from a type declaration
 
   $ cat > remove_private.mli << EOF
-  > type t = int
+  > type t = { a : int; b : float }
   > EOF
 
 We generate the .cmi file
@@ -22,4 +22,29 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_private.cmi
   diff module Remove_private:
-  type t = -private int
+   type t = -private ....
+  
+  [1]
+
+# Removing a private type abbreviation from a type declaration and modifying record fields
+
+  $ cat > remove_private_modify_record.mli << EOF
+  > type t = { a : float }
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc remove_private_modify_record.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi remove_private_modify_record.cmi
+  diff module Remove_private_modify_record:
+   type t = -private {
+     ...
+  -  a : int;
+  +  a : float;
+  -  b : float;
+   }
+  
+  [1]

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -22,7 +22,8 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_private.cmi
   diff module Remove_private:
-   type t = -private ....
+   type t = 
+   -   private
   
   [1]
 
@@ -40,11 +41,13 @@ Run the api-watcher on the two cmi files
 
   $ api-diff ref.cmi remove_private_modify_record.cmi
   diff module Remove_private_modify_record:
-   type t = -private {
-     ...
-  -  a : int;
-  +  a : float;
-  -  b : float;
-   }
+   type t =
+   -   private 
+       {
+         ...
+  -      a : int;
+  +      a : float;
+  -      b : float;
+       }
   
   [1]

--- a/tests/api-diff/type_tests.t
+++ b/tests/api-diff/type_tests.t
@@ -30,7 +30,7 @@ Run api-watcher on the two cmi files, there should be a difference
   $ api-diff ref.cmi add_type.cmi
   diff module Add_type:
   +type added_t = float
-  
+
   [1]
 
 ### A file with a removed type:
@@ -68,8 +68,7 @@ Run api-watcher on the two cmi files, there should be a difference
 
   $ api-diff ref.cmi modify_type.cmi
   diff module Modify_type:
-  type t =
-  -   int
-  +   float
-  
+   -type t = int 
+   +type t = float
+
   [1]

--- a/tests/api-diff/type_tests.t
+++ b/tests/api-diff/type_tests.t
@@ -68,7 +68,7 @@ Run api-watcher on the two cmi files, there should be a difference
 
   $ api-diff ref.cmi modify_type.cmi
   diff module Modify_type:
-   -type t = int 
-   +type t = float
-
+  -type t = int
+  +type t = float
+  
   [1]

--- a/tests/api-diff/type_tests.t
+++ b/tests/api-diff/type_tests.t
@@ -30,7 +30,7 @@ Run api-watcher on the two cmi files, there should be a difference
   $ api-diff ref.cmi add_type.cmi
   diff module Add_type:
   +type added_t = float
-
+  
   [1]
 
 ### A file with a removed type:
@@ -70,5 +70,6 @@ Run api-watcher on the two cmi files, there should be a difference
   diff module Modify_type:
   -type t = int
   +type t = float
+   
   
   [1]

--- a/tests/api-diff/type_tests.t
+++ b/tests/api-diff/type_tests.t
@@ -70,6 +70,5 @@ Run api-watcher on the two cmi files, there should be a difference
   diff module Modify_type:
   -type t = int
   +type t = float
-   
   
   [1]

--- a/tests/api-diff/type_tests.t
+++ b/tests/api-diff/type_tests.t
@@ -68,7 +68,8 @@ Run api-watcher on the two cmi files, there should be a difference
 
   $ api-diff ref.cmi modify_type.cmi
   diff module Modify_type:
-  -type t = int
-  +type t = float
+  type t =
+  -   int
+  +   float
   
   [1]


### PR DESCRIPTION
This should resolve #114, #115 and #116.

The PR will have the following changes:

- [x] Update the type declaration diff representation to be a record type, having type_kind, type_privacy and type_manifest diffs
- [x] Update the Text_diff module accordingly
- [x] New cram tests to test the above