### PR TITLE
Improve textual diff representation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
   - Improve the diff representation of type declarations with more fine grained diffing of
     type kind, type privacy and type manifest (#120, @azzsal)
   - Improve the diff representation of type declarations to have type parameters diff (#113,@azzsal)
+  - Improve the textual diff representation output to have highlighting of exact
+    changes in a line (#126,@azzsal)
 
 ### Deprecated
 

--- a/lib/api_watch.ml
+++ b/lib/api_watch.ml
@@ -3,3 +3,4 @@ module Diff = Diff
 module Text_diff = Text_diff
 module Library = Library
 module Normalize = Normalize
+module Stddiff = Stddiff

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -1,6 +1,5 @@
 type type_modification = {
-  type_kind :
-    (Types.type_decl_kind, type_kind) Stddiff.atomic_variant_maybe_changed;
+  type_kind : (Types.type_decl_kind, type_kind) Stddiff.maybe_changed;
   type_privacy : (Asttypes.private_flag, type_privacy) Stddiff.maybe_changed;
   type_manifest : Types.type_expr Stddiff.atomic_option;
   type_params : (Types.type_expr, type_param) Stddiff.list_;
@@ -8,10 +7,8 @@ type type_modification = {
 
 and type_kind =
   | Record_tk of (Types.label_declaration, label) Stddiff.map
-  | Variant_tk of
-      ( Types.constructor_declaration,
-        (Types.constructor_arguments, cstr_args) Stddiff.atomic_variant )
-      Stddiff.map
+  | Variant_tk of (Types.constructor_declaration, cstr_args) Stddiff.map
+  | Atomic_tk of Types.type_decl_kind Stddiff.atomic_modification
 
 and label = {
   label_type : Types.type_expr Stddiff.maybe_changed_atomic;
@@ -24,6 +21,7 @@ and field_mutability = Added_m | Removed_m
 and cstr_args =
   | Record_cstr of (Types.label_declaration, label) Stddiff.map
   | Tuple_cstr of Types.type_expr Stddiff.maybe_changed_atomic_entry list
+  | Atomic_cstr of Types.constructor_arguments Stddiff.atomic_modification
 
 and type_privacy = Added_p | Removed_p
 and type_param = (Types.type_expr, type_param_diff) Stddiff.maybe_changed

--- a/lib/diff.mli
+++ b/lib/diff.mli
@@ -1,87 +1,65 @@
-type ('item, 'diff) t = Added of 'item | Removed of 'item | Modified of 'diff
-type 'a atomic_modification = { reference : 'a; current : 'a }
-
-type value = {
-  vname : string;
-  vdiff :
-    (Types.value_description, Types.value_description atomic_modification) t;
+type type_modification = {
+  type_kind :
+    (Types.type_decl_kind, type_kind) Stddiff.atomic_variant_maybe_changed;
+  type_privacy : (Asttypes.private_flag, type_privacy) Stddiff.maybe_changed;
+  type_manifest : Types.type_expr Stddiff.atomic_option;
+  type_params : (Types.type_expr, type_param) Stddiff.list_;
 }
 
-type type_ = {
-  tname : string;
-  tdiff : (Types.type_declaration, type_modification) t;
+and type_kind =
+  | Record_tk of (Types.label_declaration, label) Stddiff.map
+  | Variant_tk of
+      ( Types.constructor_declaration,
+        (Types.constructor_arguments, cstr_args) Stddiff.atomic_variant )
+      Stddiff.map
+
+and label = {
+  label_type : Types.type_expr Stddiff.maybe_changed_atomic;
+  label_mutable :
+    (Asttypes.mutable_flag, field_mutability) Stddiff.maybe_changed;
 }
 
-and type_modification = {
-  type_kind : (Types.type_decl_kind, type_kind) maybe_changed;
-  type_privacy : (Asttypes.private_flag, type_privacy) maybe_changed;
-  type_manifest :
-    ( Types.type_expr option,
-      (Types.type_expr, Types.type_expr atomic_modification) t )
-    maybe_changed;
-  type_params : (Types.type_expr list, type_param list) maybe_changed;
-}
+and field_mutability = Added_m | Removed_m
 
-and ('same, 'different) maybe_changed =
-  | Same of 'same
-  | Different of 'different
+and cstr_args =
+  | Record_cstr of (Types.label_declaration, label) Stddiff.map
+  | Tuple_cstr of Types.type_expr Stddiff.maybe_changed_atomic_entry list
 
-and type_param = (Types.type_expr, type_param_diff) maybe_changed
+and type_privacy = Added_p | Removed_p
+and type_param = (Types.type_expr, type_param_diff) Stddiff.maybe_changed
 
 and type_param_diff =
   | Added_tp of Types.type_expr
   | Removed_tp of Types.type_expr
 
-and type_privacy = Added_p | Removed_p
-
-and type_kind =
-  | Record_tk of record_field list
-  | Variant_tk of constructor_ list
-  | Atomic_tk of Types.type_decl_kind atomic_modification
-
-and record_field = {
-  rname : string;
-  rdiff :
-    (Types.label_declaration, Types.label_declaration atomic_modification) t;
+type type_ = {
+  tname : string;
+  tdiff : (Types.type_declaration, type_modification) Stddiff.entry;
 }
 
-and constructor_ = {
-  csname : string;
-  csdiff : (Types.constructor_declaration, constructor_modification) t;
+type value = {
+  vname : string;
+  vdiff : Types.value_description Stddiff.atomic_entry;
 }
-
-and constructor_modification =
-  | Record_c of record_field list
-  | Tuple_c of tuple_component list
-  | Atomic_c of Types.constructor_declaration atomic_modification
-
-and tuple_component =
-  ( Types.type_expr,
-    (Types.type_expr, Types.type_expr atomic_modification) t )
-  maybe_changed
 
 type class_ = {
   cname : string;
-  cdiff :
-    (Types.class_declaration, Types.class_declaration atomic_modification) t;
+  cdiff : Types.class_declaration Stddiff.atomic_entry;
 }
 
-and cltype = {
+type cltype = {
   ctname : string;
-  ctdiff :
-    ( Types.class_type_declaration,
-      Types.class_type_declaration atomic_modification )
-    t;
+  ctdiff : Types.class_type_declaration Stddiff.atomic_entry;
 }
 
 type module_ = {
   mname : string;
-  mdiff : (Types.module_declaration, signature_modification) t;
+  mdiff : (Types.module_declaration, signature_modification) Stddiff.entry;
 }
 
 and modtype = {
   mtname : string;
-  mtdiff : (Types.modtype_declaration, signature_modification) t;
+  mtdiff : (Types.modtype_declaration, signature_modification) Stddiff.entry;
 }
 
 and signature_modification = Unsupported | Supported of sig_item list
@@ -101,4 +79,6 @@ val interface :
   module_ option
 
 val library :
-  reference:Library.t -> current:Library.t -> module_ option String_map.t
+  reference:Types.signature String_map.t ->
+  current:Types.signature String_map.t ->
+  module_ option String_map.t

--- a/lib/stddiff.ml
+++ b/lib/stddiff.ml
@@ -28,3 +28,48 @@ type 'same maybe_changed_atomic_entry =
 type ('same, 'diff) option_ = ('same option, ('same, 'diff) entry) maybe_changed
 type 'same atomic_option = ('same, 'same atomic_modification) option_
 type ('same, 'diff) list_ = ('same list, 'diff list) maybe_changed
+
+let diff_list :
+      'a 'diff.
+      diff_one:('a option -> 'a option -> ('a, 'diff) maybe_changed) ->
+      ref_list:'a list ->
+      cur_list:'a list ->
+      ('a list, ('a, 'diff) maybe_changed list) maybe_changed =
+ fun ~diff_one ~ref_list ~cur_list ->
+  let rec aux reference current (acc, all) =
+    match (reference, current) with
+    | [], [] -> (List.rev acc, all)
+    | h1 :: t1, [] -> aux t1 [] (diff_one (Some h1) None :: acc, false)
+    | [], h2 :: t2 -> aux [] t2 (diff_one None (Some h2) :: acc, false)
+    | h1 :: t1, h2 :: t2 ->
+        let res = diff_one (Some h1) (Some h2) in
+        let same = match res with Same _ -> true | Changed _ -> false in
+        aux t1 t2 (res :: acc, same && all)
+  in
+  let list_diff, all_same = aux ref_list cur_list ([], true) in
+  if all_same then Same ref_list else Changed list_diff
+
+let diff_map ~(diff_one : 'a -> 'a -> 'diff option) ~(ref_map : 'a String_map.t)
+    ~(cur_map : 'a String_map.t) : ('a, 'diff) map =
+  let same_seq, changed_seq =
+    String_map.merge
+      (fun _ ref_opt cur_opt ->
+        match (ref_opt, cur_opt) with
+        | None, None -> None
+        | Some ref, None -> Some (Changed (Removed ref))
+        | None, Some cur -> Some (Changed (Added cur))
+        | Some ref, Some cur -> (
+            match diff_one ref cur with
+            | None -> Some (Same ref)
+            | Some diff -> Some (Changed (Modified diff))))
+      ref_map cur_map
+    |> String_map.to_seq
+    |> Seq.partition_map (fun (name, i) ->
+           match i with
+           | Same i -> Either.Left (name, i)
+           | Changed i -> Either.Right (name, i))
+  in
+  {
+    same_map = String_map.of_seq same_seq;
+    changed_map = String_map.of_seq changed_seq;
+  }

--- a/lib/stddiff.ml
+++ b/lib/stddiff.ml
@@ -27,14 +27,4 @@ type 'same maybe_changed_atomic_entry =
 
 type ('same, 'diff) option_ = ('same option, ('same, 'diff) entry) maybe_changed
 type 'same atomic_option = ('same, 'same atomic_modification) option_
-
-type ('same, 'diff) variant =
-  | Same_variant of 'same
-  | Different_variant of 'diff
-
-type ('same, 'diff) atomic_variant = ('diff, 'same atomic_modification) variant
-
-type ('same, 'diff) atomic_variant_maybe_changed =
-  ('same, ('diff, 'same atomic_modification) variant) maybe_changed
-
 type ('same, 'diff) list_ = ('same list, 'diff list) maybe_changed

--- a/lib/stddiff.ml
+++ b/lib/stddiff.ml
@@ -1,0 +1,40 @@
+(** Type aliases for representing common OCaml types diffs *)
+
+(** Represent a change of an entry in a collection *)
+type ('item, 'diff) entry =
+  | Added of 'item
+  | Removed of 'item
+  | Modified of 'diff
+
+type 'a atomic_modification = { reference : 'a; current : 'a }
+(** The simplest diff representation for the modification of a value of type 'a.
+    [reference] is the value before and [current] is the value after the change
+    occured. Use this type when there is no better representation available. *)
+
+type ('item, 'diff) map = {
+  same_map : 'item String_map.t;
+  changed_map : ('item, 'diff) entry String_map.t;
+}
+
+type ('same, 'change) maybe_changed = Same of 'same | Changed of 'change
+type 'item atomic_entry = ('item, 'item atomic_modification) entry
+
+type 'same maybe_changed_atomic =
+  ('same, 'same atomic_modification) maybe_changed
+
+type 'same maybe_changed_atomic_entry =
+  ('same, 'same atomic_entry) maybe_changed
+
+type ('same, 'diff) option_ = ('same option, ('same, 'diff) entry) maybe_changed
+type 'same atomic_option = ('same, 'same atomic_modification) option_
+
+type ('same, 'diff) variant =
+  | Same_variant of 'same
+  | Different_variant of 'diff
+
+type ('same, 'diff) atomic_variant = ('diff, 'same atomic_modification) variant
+
+type ('same, 'diff) atomic_variant_maybe_changed =
+  ('same, ('diff, 'same atomic_modification) variant) maybe_changed
+
+type ('same, 'diff) list_ = ('same list, 'diff list) maybe_changed

--- a/lib/stddiff.mli
+++ b/lib/stddiff.mli
@@ -27,14 +27,4 @@ type 'same maybe_changed_atomic_entry =
 
 type ('same, 'diff) option_ = ('same option, ('same, 'diff) entry) maybe_changed
 type 'same atomic_option = ('same, 'same atomic_modification) option_
-
-type ('same, 'diff) variant =
-  | Same_variant of 'same
-  | Different_variant of 'diff
-
-type ('same, 'diff) atomic_variant = ('diff, 'same atomic_modification) variant
-
-type ('same, 'diff) atomic_variant_maybe_changed =
-  ('same, ('diff, 'same atomic_modification) variant) maybe_changed
-
 type ('same, 'diff) list_ = ('same list, 'diff list) maybe_changed

--- a/lib/stddiff.mli
+++ b/lib/stddiff.mli
@@ -28,3 +28,16 @@ type 'same maybe_changed_atomic_entry =
 type ('same, 'diff) option_ = ('same option, ('same, 'diff) entry) maybe_changed
 type 'same atomic_option = ('same, 'same atomic_modification) option_
 type ('same, 'diff) list_ = ('same list, 'diff list) maybe_changed
+
+val diff_list :
+  'a 'diff.
+  diff_one:('a option -> 'a option -> ('a, 'diff) maybe_changed) ->
+  ref_list:'a list ->
+  cur_list:'a list ->
+  ('a list, ('a, 'diff) maybe_changed list) maybe_changed
+
+val diff_map :
+  diff_one:('a -> 'a -> 'b option) ->
+  ref_map:'a String_map.t ->
+  cur_map:'a String_map.t ->
+  ('a, 'b) map

--- a/lib/stddiff.mli
+++ b/lib/stddiff.mli
@@ -1,0 +1,40 @@
+(** Type aliases for representing common OCaml types diffs *)
+
+(** Represent a change of an entry in a collection *)
+type ('item, 'diff) entry =
+  | Added of 'item
+  | Removed of 'item
+  | Modified of 'diff
+
+type 'a atomic_modification = { reference : 'a; current : 'a }
+(** The simplest diff representation for the modification of a value of type 'a.
+    [reference] is the value before and [current] is the value after the change
+    occured. Use this type when there is no better representation available. *)
+
+type ('item, 'diff) map = {
+  same_map : 'item String_map.t;
+  changed_map : ('item, 'diff) entry String_map.t;
+}
+
+type ('same, 'change) maybe_changed = Same of 'same | Changed of 'change
+type 'item atomic_entry = ('item, 'item atomic_modification) entry
+
+type 'same maybe_changed_atomic =
+  ('same, 'same atomic_modification) maybe_changed
+
+type 'same maybe_changed_atomic_entry =
+  ('same, 'same atomic_entry) maybe_changed
+
+type ('same, 'diff) option_ = ('same option, ('same, 'diff) entry) maybe_changed
+type 'same atomic_option = ('same, 'same atomic_modification) option_
+
+type ('same, 'diff) variant =
+  | Same_variant of 'same
+  | Different_variant of 'diff
+
+type ('same, 'diff) atomic_variant = ('diff, 'same atomic_modification) variant
+
+type ('same, 'diff) atomic_variant_maybe_changed =
+  ('same, ('diff, 'same atomic_modification) variant) maybe_changed
+
+type ('same, 'diff) list_ = ('same list, 'diff list) maybe_changed

--- a/tests/api-diff/modified_variant_type_tests.t
+++ b/tests/api-diff/modified_variant_type_tests.t
@@ -25,8 +25,11 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi add_constructor.cmi
   diff module Add_constructor:
    type rank =
-    ...
-  + | Jack
+     | Ace
+     | King
+     | Number of int
+     | Queen
+  +  | Jack
   
   [1]
 
@@ -45,12 +48,14 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi remove_constructor.cmi
   diff module Remove_constructor:
    type rank =
-    ...
-  - | Number of int
+     | Ace
+     | King
+     | Queen
+  -  | Number of int
   
   [1]
 
-### Modifying a constructor's arguments in a variant type:
+### Modifying a constructor arguments in a variant type:
 
   $ cat > modify_constructor_type.mli << EOF
   > type rank = Ace | King | Queen | Number of float
@@ -65,13 +70,15 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi modify_constructor_type.cmi
   diff module Modify_constructor_type:
    type rank =
-    ...
-  - | Number of int
-  + | Number of float
+     | Ace
+     | King
+     | Queen
+  -  | Number of int
+  +  | Number of float
   
   [1]
 
-Tests for modifying constructor's record argument
+Tests for modifying constructor record argument
 
   $ cat > shapes.mli << EOF
   > type point = float * float
@@ -89,8 +96,8 @@ We generate the .cmi file
   $ cat > add_field.mli << EOF
   > type point = float * float
   > type shape =
-  >  | Circle of { center : point; raduis: int; color:int }
-  >  | Rectangle of { lower_left: point; upper_right: point; color:int }
+  >  | Circle of { center : point; raduis : int; color : int; }
+  >  | Rectangle of { lower_left : point; upper_right : point; color : int; }
   > EOF
 
 We generate the .cmi file
@@ -102,17 +109,10 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes.cmi add_field.cmi
   diff module Add_field:
    type shape =
-    ...
-    | Circle of
-      {
-        ...
-  +     color : int;
-      }
-    | Rectangle of
-      {
-        ...
-  +     color : int;
-      }
+  -  | Circle of { center : point; raduis : int; }
+  +  | Circle of { center : point; raduis : int; color : int; }
+  -  | Rectangle of { lower_left : point; upper_right : point; }
+  +  | Rectangle of { lower_left : point; upper_right : point; color : int; }
   
   [1]
 
@@ -121,8 +121,8 @@ Run the api-watcher on the two cmi files
   $ cat > remove_field.mli << EOF
   > type point = float * float
   > type shape =
-  >  | Circle of { center : point; }
-  >  | Rectangle of { lower_left: point; upper_right: point; }
+  >   | Circle of { center : point; }
+  >   | Rectangle of { lower_left: point; upper_right: point; }
   > EOF
 
 We generate the .cmi file
@@ -134,12 +134,9 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes.cmi remove_field.cmi
   diff module Remove_field:
    type shape =
-    ...
-    | Circle of
-      {
-        ...
-  -     raduis : int;
-      }
+     | Rectangle of { lower_left : point; upper_right : point; }
+  -  | Circle of { center : point; raduis : int; }
+  +  | Circle of { center : point; }
   
   [1]
 
@@ -161,17 +158,13 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes.cmi modify_field.cmi
   diff module Modify_field:
    type shape =
-    ...
-    | Circle of
-      {
-        ...
-  -     raduis : int;
-  +     raduis : float;
-      }
+     | Rectangle of { lower_left : point; upper_right : point; }
+  -  | Circle of { center : point; raduis : int; }
+  +  | Circle of { center : point; raduis : float; }
   
   [1]
 
-Tests for modifying constructor's tuple argument
+Tests for modifying constructor tuple argument
 
   $ cat > shapes2.mli << EOF
   > type point = float * float
@@ -202,11 +195,10 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi add_component.cmi
   diff module Add_component:
    type shape =
-    ...
-  - | Circle of point * int
-  + | Circle of point * int * int
-  - | Rectangle of point * point
-  + | Rectangle of point * point * int
+  -  | Circle of point * int
+  +  | Circle of point * int * int
+  -  | Rectangle of point * point
+  +  | Rectangle of point * point * int
   
   [1]
 
@@ -228,9 +220,9 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi remove_component.cmi
   diff module Remove_component:
    type shape =
-    ...
-  - | Circle of point * int
-  + | Circle of point
+     | Rectangle of point * point
+  -  | Circle of point * int
+  +  | Circle of point
   
   [1]
 
@@ -252,8 +244,8 @@ Run the api-watcher on the two cmi files
   $ api-diff shapes2.cmi modify_component.cmi
   diff module Modify_component:
    type shape =
-    ...
-  - | Circle of point * int
-  + | Circle of point * float
+     | Rectangle of point * point
+  -  | Circle of point * int
+  +  | Circle of point * float
   
   [1]

--- a/tests/api-diff/parametrized_types_tests.t
+++ b/tests/api-diff/parametrized_types_tests.t
@@ -38,11 +38,8 @@ Run the api-watcher on the two cmi files
   diff module Add_type_var:
   -type ('a, 'b) t =
   +type ('a, 'b, 'c) t =
-    {
-      ...
-  -   b : 'b;
-  +   b : 'b * 'c;
-    }
+  -  { a : 'a; b : 'b; }
+  +  { a : 'a; b : 'b * 'c; }
   
   [1]
 
@@ -61,12 +58,9 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi remove_type_var.cmi
   diff module Remove_type_var:
   -type ('a, 'b) t =
-  +type 'a t =
-    {
-      ...
-  -   b : 'b;
-  +   b : int;
-    }
+  +type ('a) t =
+  -  { a : 'a; b : 'b; }
+  +  { a : 'a; b : int; }
   
   [1]
 
@@ -85,13 +79,8 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi change_type_var_use.cmi
   diff module Change_type_var_use:
    type ('a, 'b) t =
-    {
-      ...
-  -   a : 'a;
-  +   a : 'b;
-  -   b : 'b;
-  +   b : 'a;
-    }
+  -  { a : 'a; b : 'b; }
+  +  { a : 'b; b : 'a; }
   
   [1]
 
@@ -110,13 +99,8 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi swap_type_vars.cmi
   diff module Swap_type_vars:
    type ('t1, 't2) t =
-    {
-      ...
-  -   a : 't1;
-  +   a : 't2;
-  -   b : 't2;
-  +   b : 't1;
-    }
+  -  { a : 't1; b : 't2; }
+  +  { a : 't2; b : 't1; }
   
   [1]
 
@@ -131,7 +115,7 @@ We generate the .cmi file
 
   $ ocamlc ref2.mli
 
-# Adding a type variable to the first type and removing a type from the second one:
+# Adding a type variable to the first type and removing a one from the second:
 
   $ cat > add_remove.mli << EOF
   > type ('x, 'y) t = A of 'x * 'y
@@ -147,17 +131,13 @@ Run the api-watcher on the two cmi files
   $ api-diff ref2.cmi add_remove.cmi
   diff module Add_remove:
   -type ('t1, 't2) s =
-  +type 't1 s =
-    {
-      ...
-  -   b : 't2;
-  +   b : int;
-    }
-  -type 't1 t =
+  +type ('t1) s =
+  -  { a : 't1; b : 't2; }
+  +  { a : 't1; b : int; }
+  -type ('t1) t =
   +type ('t1, 't2) t =
-    ...
-  - | A of 't1
-  + | A of 't1 * 't2
+  -  | A of 't1
+  +  | A of 't1 * 't2
   
   [1]
 

--- a/tests/api-diff/project_comparison.t
+++ b/tests/api-diff/project_comparison.t
@@ -105,8 +105,9 @@ Run the api-diff tool on the two project versions
   diff module Mylib.Math.Advanced:
   +val cube : int -> int
    type shape =
-    ...
-  + | Triangle
+     | Circle
+     | Square
+  +  | Triangle
   
   diff module Mylib.Utils:
   +val triple : int -> int
@@ -222,8 +223,9 @@ Run the api-diff tool on the two project versions
   diff module Math.Advanced:
   +val cube : int -> int
    type shape =
-    ...
-  + | Triangle
+     | Circle
+     | Square
+  +  | Triangle
   
   diff module Utils:
   +val triple : int -> int

--- a/tests/api-diff/record_type_tests.t
+++ b/tests/api-diff/record_type_tests.t
@@ -25,10 +25,8 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi add_field.cmi
   diff module Add_field:
    type student =
-    {
-      ...
-  +   level : int;
-    }
+  -  { first_name : string; id : int option; last_name : string; }
+  +  { first_name : string; id : int option; last_name : string; level : int; }
   
   [1]
 
@@ -47,14 +45,12 @@ Run the api-watcher on the two cmi files
   $ api-diff ref.cmi remove_field.cmi
   diff module Remove_field:
    type student =
-    {
-      ...
-  -   id : int option;
-    }
+  -  { first_name : string; last_name : string; id : int option; }
+  +  { first_name : string; last_name : string; }
   
   [1]
 
-### Modifying a field's type in a record type:
+### Modifying a field type in a record type:
 
   $ cat > modify_field_type.mli << EOF
   > type student = { first_name: string; last_name: string; id: int }
@@ -69,15 +65,12 @@ Run api-watcher on the two cmi files
   $ api-diff ref.cmi modify_field_type.cmi
   diff module Modify_field_type:
    type student =
-    {
-      ...
-  -   id : int option;
-  +   id : int;
-    }
+  -  { first_name : string; last_name : string; id : int option; }
+  +  { first_name : string; last_name : string; id : int; }
   
   [1]
 
-### Modifying a field's type in a record type to a same alias type:
+### Modifying a field type in a record type to a same alias type:
 
   $ cat > alias_field_type.mli << EOF
   > type y = int option

--- a/tests/api-diff/type_kind_tests.t
+++ b/tests/api-diff/type_kind_tests.t
@@ -45,9 +45,9 @@ Run the api-watcher on record and varient type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_variant_kind.cmi
   diff module Ref_variant_kind:
    type t =
-  - { a : int; b : float; }
-  + | A of int
-  + | B of string
+  -  { a : int; b : float; }
+  +  | A of int
+  +  | B of string
   
   [1]
 
@@ -56,8 +56,8 @@ Run the api-watcher on record and abstract type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_abstract_kind.cmi
   diff module Ref_abstract_kind:
   -type t =
-  - { a : int; b : float; }
   +type t
+  -  { a : int; b : float; }
   
   [1]
 
@@ -66,8 +66,8 @@ Run the api-watcher on record and open type kinds cmi files
   $ api-diff ref_record_kind.cmi ref_open_kind.cmi
   diff module Ref_open_kind:
    type t =
-  - { a : int; b : float; }
-  + ..
+  -  { a : int; b : float; }
+  +  ..
   
   [1]
 

--- a/tests/api-diff/type_manifest_tests.t
+++ b/tests/api-diff/type_manifest_tests.t
@@ -45,3 +45,25 @@ Run the api-watcher on the two cmi files
   +type t = private int list
   
   [1]
+
+### Adding a type manifest, private and a record type
+
+  $ cat > add_manifest_private_record.mli << EOF
+  > type u = { a : int }
+  > type t = u = private { a : int }
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc add_manifest_private_record.mli
+
+Run the api-watcher on the two cmi files
+
+  $ api-diff ref.cmi add_manifest_private_record.cmi
+  diff module Add_manifest_private_record:
+  -type t
+  +type t = u = private
+  +  { a : int; }
+  +type u = { a : int; }
+  
+  [1]

--- a/tests/api-diff/type_privacy_tests.t
+++ b/tests/api-diff/type_privacy_tests.t
@@ -24,7 +24,7 @@ Run the api-watcher on the two cmi files
   diff module Remove_private:
   -type t = private
   +type t =
-    { a : int; b : float; }
+     { a : int; b : float; }
   
   [1]
 
@@ -44,12 +44,7 @@ Run the api-watcher on the two cmi files
   diff module Remove_private_modify_record:
   -type t = private
   +type t =
-    {
-      ...
-  -   a : int;
-  +   a : float;
-  -   b : float;
-    }
+  -  { a : int; b : float; }
+  +  { a : float; }
   
   [1]
-


### PR DESCRIPTION
This PR has multiple changes:
- Make the structural diff representation more readable by introducing some type aliases for common diff types
- Improve the structural diff representation to store context
- Update the textual diff representation to be more readable by highlighting changes in a line