### PR TITLE
Fix loader with paths to module types

### DIFF
--- a/tests/api-diff/module_type_vs_module_alias.t
+++ b/tests/api-diff/module_type_vs_module_alias.t
@@ -16,7 +16,3 @@ Let's setup a test case:
   $ ocamlc -c -I . file.mli
 
   $ api-diff --main-module file . .
-  api-diff: internal error, uncaught exception:
-            Failure("Could not find module Y in Deps")
-            
-  [125]

--- a/tests/api-diff/module_type_vs_module_alias.t
+++ b/tests/api-diff/module_type_vs_module_alias.t
@@ -1,0 +1,22 @@
+This tests issue #121 (https://github.com/ocaml-semver/ocaml-api-watch/issues/121)
+
+Let's setup a test case:
+
+  $ cat > deps.mli << EOF
+  > module X : sig end
+  > module type Y = sig end
+  > EOF
+
+  $ cat > file.mli << EOF
+  > module A = Deps.X
+  > module B : Deps.Y
+  > EOF
+
+  $ ocamlc -c deps.mli
+  $ ocamlc -c -I . file.mli
+
+  $ api-diff --main-module file . .
+  api-diff: internal error, uncaught exception:
+            Failure("Could not find module Y in Deps")
+            
+  [125]


### PR DESCRIPTION
Fix #121 (with a simplified minimal reproduction in the test).

Consider the following signature items:
```
module A = A.B.X
module B : A.B.Y
```

Here, the module type of `A` is the module type of `A.B.Y` (which is a path to a module). This is represented in `Types` as `Mty_alias path`.
The module type of `B` is `A.B.Y` (which is a path to a module _type_). This is represented in `Types` as `Mty_ident path`.

Before this PR, the two cases were treated equally, as if they were path to modules.

We now distinguish the two cases.

(This PR does not address the fact that we do not expand module types during loading! But we are not diffing them anyway as of today.)