### PR TITLE
Introduce an intermediate representation for type declarations

### DIFF
--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -1,0 +1,56 @@
+module T = Types
+module TD = Intermed.TypeDecl
+
+let bool_of_private = function
+  | Asttypes.Private -> true
+  | Asttypes.Public -> false
+
+let bool_of_mutable = function
+  | Asttypes.Mutable -> true
+  | Asttypes.Immutable -> false
+
+let field lbl =
+  {
+    TD.Field.id = lbl.T.ld_id;
+    mutable_ = bool_of_mutable lbl.ld_mutable;
+    type_ = lbl.ld_type;
+  }
+
+let cstr_args cd_args =
+  match cd_args with
+  | T.Cstr_tuple type_exprs -> TD.Constructor.Tuple type_exprs
+  | T.Cstr_record lbls -> Record (List.map field lbls)
+
+let cstr cd = { TD.Constructor.id = cd.T.cd_id; args = cstr_args cd.cd_args }
+and param p = { TD.type_expr = p }
+
+let type_declaration ~src =
+  let params = src.T.type_params in
+  let kind =
+    match (src.type_manifest, src.type_kind) with
+    | None, T.Type_abstract _ -> TD.Kind.Abstract
+    | Some manifest, Type_abstract _ ->
+        Alias { manifest; private_ = bool_of_private src.type_private }
+    | manifest, Type_open ->
+        Concrete
+          {
+            manifest;
+            private_ = bool_of_private src.type_private;
+            definition = Open;
+          }
+    | manifest, Type_record (lbls, _) ->
+        Concrete
+          {
+            manifest;
+            private_ = bool_of_private src.type_private;
+            definition = Record (List.map field lbls);
+          }
+    | manifest, Type_variant (cstrs, _) ->
+        Concrete
+          {
+            manifest;
+            private_ = bool_of_private src.type_private;
+            definition = Variant (List.map cstr cstrs);
+          }
+  in
+  { TD.params = List.map param params; kind }

--- a/lib/convert.mli
+++ b/lib/convert.mli
@@ -1,0 +1,5 @@
+(** Converts from compiler representation of different items (type_declarations,
+    value_description, etc.) to an internal intermediate representation used when diffing.
+*)
+
+val type_declaration : src:Types.type_declaration -> Intermed.TypeDecl.t

--- a/lib/intermed.ml
+++ b/lib/intermed.ml
@@ -1,0 +1,31 @@
+module rec TypeDecl : sig
+  module Field : sig
+    type t = { id : Ident.t; mutable_ : bool; type_ : Types.type_expr }
+  end
+
+  module Constructor : sig
+    type args = Tuple of Types.type_expr list | Record of Field.t list
+    type t = { id : Ident.t; args : args }
+  end
+
+  type param = { type_expr : Types.type_expr }
+
+  module Kind : sig
+    type definition =
+      | Open
+      | Record of Field.t list
+      | Variant of Constructor.t list
+
+    type t =
+      | Abstract
+      | Alias of { manifest : Types.type_expr; private_ : bool }
+      | Concrete of {
+          manifest : Types.type_expr option;
+          private_ : bool;
+          definition : definition;
+        }
+  end
+
+  type t = { params : param list; kind : Kind.t }
+end =
+  TypeDecl


### PR DESCRIPTION
This should resolve #132.

The IR is inspired by/adapted from [odoc internal representation](https://ocaml.github.io/odoc/odoc/src/odoc.model/lang.ml.html#module-TypeDecl). 
We will gradually migrate from the compiler representation to this IR. This PR starts with type declarations.